### PR TITLE
Enhance update-deps command and enable new Claude Code plugins

### DIFF
--- a/home/.claude/commands/update-deps.md
+++ b/home/.claude/commands/update-deps.md
@@ -184,6 +184,13 @@ The agent should:
    - `CHANGELOG`, `CHANGES`, `HISTORY`, `NEWS`
    - Extensions: `.md`, `.txt`, `.textile`, `.rdoc`, or no extension
 
+   **Diffend fallback for Ruby gems** — if a gem has no changelog,
+   no GitHub releases with meaningful notes, and no history file, use
+   [Diffend](https://my.diffend.io) as a last resort. Diffend shows a
+   file-level diff between gem versions. Link format:
+   `https://my.diffend.io/gems/<gem-name>/<old-version>/<new-version>`.
+   Diffend only works for RubyGems — do not use it for npm packages.
+
 3. **Add anchor tags to changelog links** — if a changelog link points
    to a file but lacks an anchor tag for the specific version, follow
    the link and find the correct heading anchor. For example, change
@@ -342,6 +349,16 @@ When a new version is available:
 2. Update the pinned version constraints in both manifest files:
    - `Gemfile`: update the `~>` constraint for `cocooned`
    - `package.json`: update the `^` constraint for `@notus.sh/cocooned`
+
+## Known Changelog Quirks
+
+### sass-embedded
+
+The `sass-embedded` Ruby gem wraps the Dart Sass compiler but does not
+maintain its own changelog or GitHub releases. For changelog details,
+use the sister repository's changelog at
+[sass/embedded-host-node](https://github.com/sass/embedded-host-node/blob/main/CHANGELOG.md)
+— versions are released in lockstep across both hosts.
 
 ## Important Notes
 

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -84,7 +84,9 @@
     "explanatory-output-style@claude-code-plugins": true,
     "playwright-cli@playwright-cli": true,
     "clangd-lsp@claude-plugins-official": true,
-    "ruby-lsp@claude-plugins-official": true
+    "ruby-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "code-review@claude-code-plugins": true
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",


### PR DESCRIPTION
## Summary

- Add [Diffend](https://my.diffend.io) as a fallback changelog source for Ruby gems that lack changelogs, GitHub releases, or history files
- Document `sass-embedded` changelog quirk, pointing to the `sass/embedded-host-node` sister repository for release notes
- Enable `frontend-design` and `code-review` plugins in Claude Code settings

## Test plan

- [x] Verify Diffend link format works for a known gem (e.g., `https://my.diffend.io/gems/rails/7.1.0/7.2.0`)
- [x] Confirm `sass-embedded` changelog link resolves correctly
- [x] Verify new plugins load in Claude Code sessions