### PR TITLE
Show git branch in iTerm2 tab titles via zsh hooks

### DIFF
--- a/.homesick_subdir
+++ b/.homesick_subdir
@@ -2,3 +2,4 @@
 .claude
 .config/gh
 Library/Application Support/Claude
+Library/Application Support/iTerm2/DynamicProfiles

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -89,8 +89,8 @@ alias brewup="brew upgrade && brew cleanup && brew autoremove && brew doctor"
 # Uncomment following line if you want to disable colors in ls
 # DISABLE_LS_COLORS="true"
 
-# Uncomment following line if you want to disable autosetting terminal title.
-# DISABLE_AUTO_TITLE="true"
+# Disable oh-my-zsh's default auto-title so our precmd/preexec hooks own it
+DISABLE_AUTO_TITLE="true"
 
 # Uncomment following line if you want red dots to be displayed while waiting for completion
 # COMPLETION_WAITING_DOTS="true"
@@ -125,6 +125,38 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Fix Ruby Debug from hanging when using save_and_open_screenshot
 export RUBY_DEBUG_FORK_MODE="parent"
+
+# iTerm2 tab title: publish shell state (dir) as an iTerm2 user variable and
+# seed session.autoName with the current git branch so idle tabs show the
+# branch; child processes (Claude Code, vim, ssh) overwrite autoName with
+# their own titles while running. Configure iTerm2 profile Title → Custom:
+#   \(session.autoName) · \(user.dir)
+# Ordering matters because iTerm2 truncates from the right — the leftmost
+# token carries the most distinguishing info when many tabs are open.
+_set_iterm2_user_var() {
+  local b64
+  b64=$(printf '%s' "$2" | base64 | tr -d '\n')
+  printf '\e]1337;SetUserVar=%s=%s\a' "$1" "$b64"
+}
+
+_tab_title_idle() {
+  local branch dir
+  branch=$(git branch --show-current 2>/dev/null)
+  [[ -z $branch ]] && branch=$(git rev-parse --short HEAD 2>/dev/null)
+  [[ -z $branch ]] && branch="no-git"
+  dir=${${PWD/#$HOME/~}:t}
+  _set_iterm2_user_var dir "$dir"
+  printf '\e]1;%s\a' "$branch"
+}
+
+# Fallback title for processes that don't emit their own OSC title.
+# Claude Code, vim with titlestring, ssh, tmux, etc. will overwrite this
+# almost immediately, which is what we want.
+_tab_title_running() { printf '\e]1;▶ %s\a' "$1" }
+
+autoload -Uz add-zsh-hook
+add-zsh-hook precmd _tab_title_idle
+add-zsh-hook preexec _tab_title_running
 
 # Note: these must be placed at the bottom of .zshrc
 source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/home/Library/Application Support/iTerm2/DynamicProfiles/main.json
+++ b/home/Library/Application Support/iTerm2/DynamicProfiles/main.json
@@ -1,0 +1,12 @@
+{
+  "Profiles": [
+    {
+      "Name": "Matt (dotfiles)",
+      "Guid": "15372224-9BD7-4C77-A9E3-5B19E73AE5F0",
+      "Dynamic Profile Parent Name": "Default",
+      "Title Components": 32,
+      "Custom Window Title": "\\(session.autoName) · \\(user.dir)",
+      "Allow Title Setting": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `precmd`/`preexec` zsh hooks that publish the current dir as an iTerm2 user variable and set the tab's `autoName` to the git branch (or short SHA) when idle, with a `▶ <cmd>` fallback for foreground processes that don't emit their own OSC title.
- Set `DISABLE_AUTO_TITLE="true"` so oh-my-zsh stops fighting the new hooks.
- Add a dynamic iTerm2 profile whose Custom Window Title template `\(session.autoName) · \(user.dir)` composes the two pieces — branch first because iTerm2 truncates from the right when tabs get crowded.
- Place the JSON at its real install path (`Library/Application Support/iTerm2/DynamicProfiles/main.json`) and add the parent directory to `.homesick_subdir` so homesick symlinks the file individually rather than replacing the whole directory iTerm2 uses for its own state.

## Per-machine setup

`homesick pull dotfiles && homesick link dotfiles` is enough — the castle path mirrors the install path, so homesick wires the symlink up automatically. Then in iTerm2:

1. Restart iTerm2 (initial dynamic-profile discovery happens at startup; subsequent edits to the JSON live-reload).
2. Open **Settings → Profiles**, select **Matt (dotfiles)** in the sidebar, click **Other Actions… → Set as Default**.
3. Open a fresh tab with ⌘T to verify.

## Test plan

- [x] Source `~/.zshrc` in a new iTerm2 tab and confirm idle tabs read `<branch> · <dir>`
- [x] Run a long command (`vim`, `claude`, `ssh somewhere`) and confirm the tool's own title takes over
- [x] After the command exits, confirm the title returns to the branch on the next prompt
- [x] `cd` between repos and confirm the branch updates on each prompt
- [x] In a non-git directory, confirm the title shows `no-git` rather than erroring
- [x] On a fresh machine, run `homesick link dotfiles` and confirm `~/Library/Application Support/iTerm2/DynamicProfiles/main.json` symlinks correctly without iTerm2's existing state in that dir being clobbered