### PR TITLE
Redirect vim undo files outside the homesick castle

### DIFF
--- a/home/.vimrc
+++ b/home/.vimrc
@@ -93,8 +93,15 @@ set shortmess=atI
 set visualbell " stop Vim from beeping at me
 " set cursorline " Highlight the current line
 
-" Maintain the undo history even after the file is closed:
+" Maintain the undo history even after the file is closed.
+" Without an explicit undodir, Vim writes .un~ files next to the source — which
+" inside the homesick castle means symlinks back into ~/Library, etc. The //
+" suffix encodes the full path in the filename so undo histories don't collide.
 set undofile
+set undodir=~/.vim/undo//
+if !isdirectory(expand(&undodir))
+  call mkdir(expand(&undodir), 'p')
+endif
 
 " Softtabs, 2 spaces
 set tabstop=2


### PR DESCRIPTION
## Summary

- Vim's `set undofile` (line 97 of `home/.vimrc`) enabled persistent undo without an explicit `undodir`, so Vim wrote each `.un~` file alongside its source. Inside the homesick castle that meant a steady accumulation of `.un~` files in `home/.claude/`, `home/Library/Application Support/Claude/`, and so on — and `homesick link` symlinked them back into the live filesystem on every run.
- Set `undodir=~/.vim/undo//` so all undo histories route to a single out-of-the-way directory. The trailing `//` is a Vim convention that encodes the source file's full path into the undo filename, so two files sharing a basename don't collide.
- Add an `isdirectory` guard that creates `~/.vim/undo` on first use, since Vim silently does nothing when `undodir` points at a non-existent directory.

## Per-machine cleanup

After pulling, delete any pre-existing strays:

```bash
find ~/.homesick/repos/dotfiles/home -name '*.un~' -type f -delete
rm -f ~/Library/Application\ Support/Claude/.claude_desktop_config.json.un~
```

These are transient editor state with no value preserved across the move.

## Test plan

- [x] Open and modify a file in the castle (e.g. `vim ~/.homesick/repos/dotfiles/home/.vimrc`), save, close — confirm no `.un~` appears next to it
- [x] Confirm the corresponding undo file appears in `~/.vim/undo/` with the source path encoded in its name
- [x] Reopen the same file and press `u` to confirm undo history persisted across the close
- [x] Run `homesick link dotfiles` and confirm no `.un~` symlinks are created or prompted about