### PR TITLE
Add pr-conflicts helper and miscellaneous tooling updates

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -22,6 +22,7 @@ cask 'zeplin'
 cask 'raycast'
 cask 'rectangle'
 cask 'caffeine'
+brew 'mole' # for deep cleaning and optimizing your Mac
 
 # Programming languages and related tools
 brew 'dart'
@@ -62,6 +63,7 @@ brew 'cmake'
 brew 'ninja' # Use Ninja for cmake
 brew 'boost'
 brew 'swig'
+brew 'eigen'
 
 # For linting
 brew 'hadolint' # Dockerfile linter

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -10,6 +10,7 @@
   },
   "permissions": {
     "allow": [
+      "Bash(bin/lint-markdown *)",
       "Bash(bin/rails lint:*)",
       "Bash(bin/rails lint:coffee:*)",
       "Bash(bin/rails lint:haml:*)",

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -69,6 +69,22 @@ alias dockerclean="dockercleancontainers && dockercleanimages"
 alias docker-killall="docker ps -q | xargs docker kill"
 alias dc-es="docker compose up -d docker_elasticsearch"
 
+# GitHub
+# List open PRs with merge conflicts. PR numbers are OSC 8 hyperlinks
+# (clickable in modern terminals). Optional first arg overrides the default
+# fetch limit of 500.
+pr-conflicts() {
+  local limit=${1:-500}
+  local esc=$'\033'
+  gh pr list --limit "$limit" \
+      --json number,title,headRefName,mergeStateStatus,url \
+    | jq -r --arg esc "$esc" '
+        .[]
+        | select(.mergeStateStatus == "DIRTY")
+        | "\($esc)]8;;\(.url)\($esc)\\#\(.number)\($esc)]8;;\($esc)\\\t\(.headRefName)\t\(.title)"
+      '
+}
+
 # Homebrew
 alias bdi="brew deps --tree --installed"
 alias bubo="brew update && brew outdated"


### PR DESCRIPTION
## Summary

- Add `pr-conflicts` zsh function that lists open PRs currently in a `DIRTY` merge state via `gh pr list`. PR numbers are rendered as OSC 8 clickable hyperlinks, with a graceful fallback to plain text in older terminals. Takes an optional limit argument (default `500`).
- Add `mole` (macOS deep-clean utility) and `eigen` (C++ header library for linear algebra, used by ORE — Open Source Risk Engine) to the `Brewfile`.
- Allow `bin/lint-markdown *` in the Claude Code permissions allowlist so markdown linting runs without an approval prompt, matching the existing `bin/rails lint:*` entries.

## Test plan

- [x] Open a new shell, run `pr-conflicts` in a repo with at least one conflicted PR and confirm rows render with clickable PR numbers
- [x] Run `pr-conflicts 50` and confirm the limit argument is honored
- [ ] Run `brew bundle check` and confirm `mole` and `eigen` are reported as installable / installed
- [x] Confirm an ORE build can find `eigen` headers
- [x] In Claude Code, run `bin/lint-markdown` and confirm no permission prompt appears