### PR TITLE
Clean up local branches after rebase/squash merges

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -26,9 +26,20 @@
   up = pull --rebase --prune
   wip = !git add -A && git commit -m "WIP"
   wipe = !git add -A && git commit -qm 'WIPE SAVEPOINT' && git reset HEAD~1 --hard
-  bclean = "!f() { git branch --merged ${1-main} | grep -v " ${1-main}$" | xargs -r git branch -d; }; f"
+
+  # Delete local branches whose patches are all merged into the given base
+  # (default `main`). Like `cleanup`, but parameterized so you can clean up
+  # against any base branch (e.g. `git bclean develop`).
+  bclean = "!f() { base=${1-main}; git branch --format='%(refname:short)' | grep -v \"^${base}$\" | while read b; do [ -z \"$(git cherry \"$base\" \"$b\" | grep '^+')\" ] && git branch -D \"$b\"; done; }; f"
+
+  # Post-PR tidy-up: switch to base branch (default `main`), pull latest,
+  # then prune any local branches that are now merged into it.
   bdone = "!f() { git checkout ${1-main} && git up && git bclean ${1-main}; }; f"
+
+  # List all refs (local + remote branches, tags) sorted by most-recent
+  # commit. Scan the bottom of the output to spot stale branches to prune.
   springcleaning = for-each-ref --sort=-committerdate --format='%(refname:short) %(committerdate:short)'
+
   stash-all = stash save --include-untracked
   grog = log --graph --abbrev-commit --decorate --all --format=format:\"%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n %C(white)%s%C(reset)\"
   recent = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(refname:short)"

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -33,8 +33,11 @@
   grog = log --graph --abbrev-commit --decorate --all --format=format:\"%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n %C(white)%s%C(reset)\"
   recent = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(refname:short)"
   rc = rebase --continue
-  # Removed merged branches:
-  cleanup = "!git branch --merged | grep  -v '\\*\\|main' | xargs -n 1 git branch -d"
+
+  # Remove branches whose changes are already in main, including ones
+  # merged via "Rebase and merge" or "Squash and merge" (which rewrite SHAs,
+  # so `git branch --merged` misses them). `git cherry` compares by patch-id.
+  cleanup = "!f() { git branch --format='%(refname:short)' | grep -v '^main$' | while read b; do [ -z \"$(git cherry main \"$b\" | grep '^+')\" ] && git branch -D \"$b\"; done; }; f"
   pc = "!f() { git pull && git cleanup; }; f"
 
   # list of deleted files:


### PR DESCRIPTION
## Summary

- Replaces `git branch --merged` with `git cherry` (patch-id comparison) in the `cleanup` and `bclean` aliases, so branches whose PRs were merged via GitHub's "Rebase and merge" or "Squash and merge" are now cleaned up automatically — previously, only traditional merge commits were detected.
- `git pc` and `git bdone` (which call `cleanup` / `bclean` internally) inherit the new behavior with no change to their interfaces, and `bclean`'s optional base-branch argument (e.g. `git bclean develop`) is preserved.
- Adds documentation comments above `bclean`, `bdone`, and `springcleaning` explaining what each alias is for, since the names alone don't convey when to reach for them.

## Test plan

- [x] On a repo that uses "Rebase and merge" (e.g. `fastererer`), merge a PR, switch to `main`, run `git pc`, and confirm the local branch is deleted.
- [x] On a repo that uses "Squash and merge", merge a PR, switch to `main`, run `git pc`, and confirm the local branch is deleted.
- [x] On a repo that uses traditional merge commits, confirm `git pc` still cleans up merged branches (regression check).
- [x] Run `git bclean develop` against a non-`main` base branch and confirm the parameterized form still works.
- [x] Confirm branches with unmerged commits are NOT deleted (a branch with a `+` line from `git cherry` should be left alone).