### PR TITLE
Remove unused and redundant Brewfile entries

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,8 +11,6 @@ brew 'zsh-autosuggestions'
 brew 'zsh-syntax-highlighting'
 
 # Web Development tools
-brew 'puma/puma/puma-dev'
-brew 'sass/sass/migrator'
 cask 'firefox'
 cask 'tableplus'
 cask 'miro'
@@ -25,12 +23,10 @@ cask 'caffeine'
 brew 'mole' # for deep cleaning and optimizing your Mac
 
 # Programming languages and related tools
-brew 'dart'
 brew 'rust' # for running Ruby with the YJIT compiler
 brew 'rbenv'
 brew 'ruby-build'
 brew 'node'
-brew 'corepack' # for help with managing versions of your package managers, related to Node.js
 brew 'uv' # Python package installer, runner, and virtualenv manager
 
 # Version Control tools
@@ -50,7 +46,6 @@ brew 'poppler' # for creating PDF previews
 
 # Hosting tools
 brew 'heroku'
-brew 'flyctl'
 
 # For CIRM's infrastructure management
 brew 'ansible'
@@ -78,7 +73,6 @@ cask 'calibre'
 cask 'typora'
 cask 'zoom'
 cask 'cleanmymac'
-cask 'qlmarkdown'
 
 # For Claude Code
 brew 'gum' # Interactive terminal UI for multi-select menus in Claude Code commands


### PR DESCRIPTION
## Summary

- Homebrew's new tap-trust model surfaced several stale `Brewfile` entries via `brew doctor` and `brew bundle check`. Audited and removed the ones that are unused or redundant:
- **Untrusted third-party taps** (`dart-lang/dart`, `oven-sh/bun`, `puma/puma`, `sass/sass`): `puma-dev` is unmaintained, `sass-migrator` is a reinstallable one-off tool, `dart` was unused (`dartsass-rails` vendors its own compiler via the `sass-embedded` gem), and `oven-sh/bun` was an empty leftover tap.
- **`corepack`**: redundant — modern `node` bundles corepack, so the standalone formula is unnecessary.
- **`flyctl`**: unused — nothing here deploys to Fly.io, and it was never installed.
- **`qlmarkdown`**: superseded by Typora for Markdown, which is already tracked in the `Brewfile`.
- The taps and formulae have already been untapped/uninstalled locally where applicable.

## Test plan

- [x] `brew doctor` no longer emits the "following taps are not trusted" warning
- [x] `corepack --version` still works (provided by `node`)
- [x] A `brew bundle` run does not reinstall `puma-dev`, `sass-migrator`, `dart`, `corepack`, `flyctl`, or `qlmarkdown`