### PR TITLE
Tidy up brewup cask handling, gitignore, and add Zed cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ cask 'firefox'
 cask 'tableplus'
 cask 'miro'
 cask 'zeplin'
+cask 'zed'
 
 # MacOS interface management tools
 cask 'raycast'

--- a/home/.gitignore_global
+++ b/home/.gitignore_global
@@ -51,6 +51,12 @@ Thumbs.db
 # Claude and MCP related files #
 #############################
 /.serena/*
+**/.claude/agent-memory
 
 # Claude local settings (machine-specific)
 **/.claude/settings.local.json
+
+# Python generated files #
+##########################
+__pycache__/
+*.pyc

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -88,7 +88,7 @@ pr-conflicts() {
 # Homebrew
 alias bdi="brew deps --tree --installed"
 alias bubo="brew update && brew outdated"
-alias brewup="brew upgrade && brew cleanup && brew autoremove && brew doctor"
+alias brewup="HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1 brew upgrade && brew cleanup && brew autoremove && brew doctor"
 # Consider using `brew cleanup --prune=all --dry-run`
 # See https://mac.install.guide/homebrew/8
 


### PR DESCRIPTION
## Summary

A few small dotfiles maintenance changes:

- **Stop `brewup` from fighting self-updating casks.** Apps like GitHub Desktop patch themselves in `/Applications` ahead of Homebrew's recorded version, so every `brewup` flagged them as outdated and then failed with an "already an App at ..." error. The `brewup` alias now prefixes the upgrade step with `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1`, scoped inline so `cleanup`/`autoremove`/`doctor` are unaffected.
- **Ignore generated noise globally.** Added `**/.claude/agent-memory` (machine-local Claude Code agent memory) and a Python artifacts section (`__pycache__/`, `*.pyc`) to `.gitignore_global`.
- **Add the Zed editor cask** so it installs via `brew bundle` on a fresh machine.

## Test plan

- [ ] `source ~/.zshrc` and run `brewup` — GitHub Desktop (and other `auto_updates true` casks) are skipped cleanly, no "already an App" error
- [x] Confirm `__pycache__/`, `*.pyc`, and `.claude/agent-memory` no longer appear in `git status` across repos
- [x] `brew bundle` installs `zed` without error
