### PR TITLE
Replace CircleCI MCP server with the CircleCI CLI

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -35,6 +35,11 @@ brew 'git'
 brew 'gh' # for the GitHub CLI
 cask 'github'
 
+# Continuous Integration tools
+# Requires a one-time `brew trust --cask circleci-public/circleci/circleci@next` before `brew bundle`
+tap 'circleci-public/circleci'
+cask 'circleci-public/circleci/circleci@next' # CircleCI CLI (preview build)
+
 # Databases
 brew 'sqlite'
 brew 'redis'

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ Ruby development tools via [rbenv][rbenv_link], and a curated set of
 
 1. Install tools managed by Homebrew
 
+    The Brewfile installs the CircleCI CLI from a third-party tap, which Homebrew's cask-trust gate
+    blocks until it is explicitly trusted. Run the one-time `brew trust` first, then `brew bundle`:
+
     ```shell
     $ cd ~/.homesick/repos/dotfiles/
+    $ brew trust --cask circleci-public/circleci/circleci@next
     $ brew bundle
     ```
 

--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -43,7 +43,6 @@
       "mcp__chrome-devtools__select_page",
       "mcp__chrome-devtools__take_screenshot",
       "mcp__chrome-devtools__take_snapshot",
-      "mcp__circleci-mcp-server__get_job_test_results",
       "mcp__linear-server__get_issue",
       "mcp__linear-server__get_issue_status",
       "mcp__linear-server__get_project",


### PR DESCRIPTION
## Summary

- Migrate from the legacy npx-based CircleCI MCP server (`@circleci/mcp-server-circleci`) to the official CircleCI CLI, which CircleCI now recommends over the standalone MCP server
- Add the CircleCI CLI (`circleci@next` cask + `circleci-public/circleci` tap) to the `Brewfile`, with a note about the one-time `brew trust --cask …` step the untrusted tap requires
- Remove the now-orphaned `mcp__circleci-mcp-server__get_job_test_results` permission from the Claude settings allowlist
- Security bonus: the old server stored a plaintext `CIRCLECI_TOKEN` in the untracked live config; the CLI authenticates via `circleci auth login` and its own config file, so no token is embedded in any MCP registration

The live MCP registrations (Claude Code via `~/.claude.json`, Claude Desktop via its app-support config) are machine-local and untracked, so they're set up outside this repo using the CLI's `mcp` subcommands.

## Test plan

- [x] `brew trust --cask circleci-public/circleci/circleci@next` (one-time, clears the untrusted-tap gate)
- [x] `brew bundle` installs `circleci@next` cleanly
- [x] `circleci auth login` succeeds and `circleci auth me` shows the expected account
- [x] Claude Code: `claude mcp get circleci-cli` shows **Connected**
- [x] Claude Desktop: after restart, the `circleci-cli` server appears and its tools respond