### PR TITLE
Resolve the base branch in git cleanup instead of assuming main

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -45,10 +45,30 @@
   recent = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(refname:short)"
   rc = rebase --continue
 
-  # Remove branches whose changes are already in main, including ones
-  # merged via "Rebase and merge" or "Squash and merge" (which rewrite SHAs,
-  # so `git branch --merged` misses them). `git cherry` compares by patch-id.
-  cleanup = "!f() { git branch --format='%(refname:short)' | grep -v '^main$' | while read b; do [ -z \"$(git cherry main \"$b\" | grep '^+')\" ] && git branch -D \"$b\"; done; }; f"
+  # Remove branches whose changes are already in the base branch, including
+  # ones merged via "Rebase and merge" or "Squash and merge" (which rewrite
+  # SHAs, so `git branch --merged` misses them). `git cherry` compares by
+  # patch-id.
+  #
+  # The base is read from origin/HEAD, falling back to whichever of main or
+  # master exists. It must never be hardcoded: `git cherry` prints nothing to
+  # stdout when its upstream does not resolve, so an emptiness test against a
+  # wrong base reads as "fully merged" and force-deletes every branch.
+  cleanup = "!f() { \
+    base=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||'); \
+    if [ -z \"$base\" ]; then for c in main master; do git show-ref --verify --quiet \"refs/heads/$c\" && { base=$c; break; }; done; fi; \
+    if [ -z \"$base\" ]; then echo 'cleanup: cannot determine the base branch; aborting' >&2; return 1; fi; \
+    if git show-ref --verify --quiet \"refs/heads/$base\"; then ref=$base; \
+    elif git show-ref --verify --quiet \"refs/remotes/origin/$base\"; then ref=origin/$base; \
+    else echo \"cleanup: base branch '$base' not found locally or on origin; aborting\" >&2; return 1; fi; \
+    cur=$(git symbolic-ref --quiet --short HEAD); \
+    echo \"cleanup: comparing against $ref\"; \
+    git branch --format='%(refname:short)' | while read -r b; do \
+      if [ \"$b\" = \"$base\" ] || [ \"$b\" = \"$cur\" ]; then continue; fi; \
+      if ! out=$(git cherry \"$ref\" \"$b\" 2>/dev/null); then echo \"cleanup: skipping $b (cannot compare)\" >&2; continue; fi; \
+      if ! printf '%s' \"$out\" | grep -q '^+'; then git branch -D \"$b\"; fi; \
+    done; \
+  }; f"
   pc = "!f() { git pull && git cleanup; }; f"
 
   # list of deleted files:


### PR DESCRIPTION
## Summary

- `git cleanup` (and therefore `git pc`, which calls it) force-deleted **every** branch in any repository whose base branch is not named `main`. Running it in a `master`-based repo destroyed that repo's entire set of local branches, unmerged work included.
- The cause is an emptiness test standing in for a success test. The old alias compared each branch against a hardcoded `main`:

  ```sh
  [ -z "$(git cherry main "$b" | grep '^+')" ] && git branch -D "$b"
  ```

  When `main` does not resolve, `git cherry` writes `fatal: unknown commit main` to **stderr** and prints nothing to stdout. The substitution is therefore empty, `[ -z "" ]` is true, and the branch is force-deleted. The guard inverts into a delete-everything loop precisely when its reference is wrong — and it fails silently, because the `fatal:` lines scroll past interleaved with the deletions.
- The base branch is now resolved rather than assumed: read from `origin/HEAD`, falling back to whichever of `main` or `master` exists locally, and further to `origin/<base>` when the local branch is absent.
- Failure is now loud rather than permissive. If no base resolves, the command aborts and deletes nothing. If `git cherry` fails for an individual branch, that branch is skipped instead of being treated as merged — the exit status is checked, not the output length.
- The base actually in use is echoed before any deletion happens, so a wrong guess is visible before the damage rather than after.
- The current branch is never considered, and the base branch is excluded by name rather than by `grep -v '^main$'`.
- The comment above the alias now records *why* the base must not be hardcoded, so the failure mode is not reintroduced by someone simplifying the resolution logic.

## Verification

Tested in scratch repositories on git 2.55:

- **`master`-based repo** — a merged branch is deleted, an unmerged branch survives.
- **`main`-based repo, squash-merged branch** — still deleted, confirming the patch-id comparison that is the alias's whole reason for existing over `git branch --merged`.
- **No resolvable base** (repo on `trunk`, no `origin/HEAD`) — aborts with a message and deletes nothing.
- **Current branch fully merged** — not deleted.
- **The old alias, run verbatim in a `master` repo** — reproduced the failure exactly, deleting an unmerged branch and emitting the same `fatal: unknown commit main` / `cannot delete branch 'master' used by worktree` output seen in the real incident.

## Test plan

- [ ] Run `git pc` in a `main`-based repo and confirm merged branches are removed and unmerged ones kept
- [ ] Run `git pc` in a `master`-based repo and confirm the same, with `cleanup: comparing against master` printed first
- [ ] Confirm a branch merged via "Squash and merge" is still detected and removed
- [ ] Run `git cleanup` in a repo with an unusual base (e.g. `trunk`) with no `origin/HEAD` and confirm it aborts without deleting
