### PR TITLE
Fix the assumed main base in git bclean and bdone

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -11,7 +11,11 @@
   remote-branches = for-each-ref --sort=-committerdate --format=\"%(color:blue)%(authordate:relative)\t%(color:red)%(authorname)\t%(color:white)%(color:bold)%(refname:short)\" refs/remotes
   ci = commit -v
   co = checkout
-  com = checkout main
+  com = "!f() { \
+    [ $# -eq 0 ] || { echo 'com: takes no arguments' >&2; return 1; }; \
+    base=$(git base) || return 1; \
+    git checkout \"$base\" --; \
+  }; f"
   cob = checkout -b
   cp = cherry-pick
   dc = diff --cached
@@ -27,17 +31,23 @@
   wip = !git add -A && git commit -m "WIP"
   wipe = !git add -A && git commit -qm 'WIPE SAVEPOINT' && git reset HEAD~1 --hard
 
-  # Delete local branches whose patches are all merged into the given base
-  # (default `main`). Like `cleanup`, but parameterized so you can clean up
-  # against any base branch (e.g. `git bclean develop`).
-  bclean = "!f() { base=${1-main}; git branch --format='%(refname:short)' | grep -v \"^${base}$\" | while read b; do [ -z \"$(git cherry \"$base\" \"$b\" | grep '^+')\" ] && git branch -D \"$b\"; done; }; f"
+  # Delete local branches whose patches are all merged into the base branch. A wrapper around
+  # `cleanup`, kept for muscle memory. Both take an optional base to compare against
+  # (e.g. `git bclean develop`) and resolve the repository's own when given none — never assume a
+  # name here, see `cleanup`.
+  bclean = !git cleanup
 
-  # Post-PR tidy-up: switch to base branch (default `main`), pull latest,
-  # then prune any local branches that are now merged into it.
-  bdone = "!f() { git checkout ${1-main} && git up && git bclean ${1-main}; }; f"
+  # Post-PR tidy-up: switch to the base branch, pull latest, then prune any local branches that are
+  # now merged into it. Takes the same optional base.
+  bdone = "!f() { \
+    base=$1; \
+    case $base in -*) echo \"bdone: invalid base '$base'\" >&2; return 1;; esac; \
+    if [ -z \"$base\" ]; then base=$(git base) || return 1; fi; \
+    git checkout \"$base\" -- && git up && git cleanup \"$base\"; \
+  }; f"
 
-  # List all refs (local + remote branches, tags) sorted by most-recent
-  # commit. Scan the bottom of the output to spot stale branches to prune.
+  # List all refs (local + remote branches, tags) sorted by most-recent commit. Scan the bottom of
+  # the output to spot stale branches to prune.
   springcleaning = for-each-ref --sort=-committerdate --format='%(refname:short) %(committerdate:short)'
 
   stash-all = stash save --include-untracked
@@ -45,31 +55,64 @@
   recent = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(refname:short)"
   rc = rebase --continue
 
-  # Remove branches whose changes are already in the base branch, including
-  # ones merged via "Rebase and merge" or "Squash and merge" (which rewrite
-  # SHAs, so `git branch --merged` misses them). `git cherry` compares by
-  # patch-id.
+  # Print the repository's base branch: origin/HEAD when it still points at a ref that exists, else
+  # whichever of main or master exists locally or on origin. Prints nothing and fails when none
+  # resolves, so callers can abort instead of guessing a name.
+  base = "!f() { \
+    b=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||'); \
+    if [ -n \"$b\" ] \
+    && [ \"$(git for-each-ref --format='%(refname)' \"refs/heads/$b\")\" != \"refs/heads/$b\" ] \
+    && [ \"$(git for-each-ref --format='%(refname)' \"refs/remotes/origin/$b\")\" != \"refs/remotes/origin/$b\" ]; then b=; fi; \
+    if [ -z \"$b\" ]; then for c in main master; do \
+      if [ \"$(git for-each-ref --format='%(refname)' \"refs/heads/$c\")\" = \"refs/heads/$c\" ] \
+      || [ \"$(git for-each-ref --format='%(refname)' \"refs/remotes/origin/$c\")\" = \"refs/remotes/origin/$c\" ]; then b=$c; break; fi; \
+    done; fi; \
+    if [ -z \"$b\" ]; then echo 'base: cannot determine the base branch' >&2; return 1; fi; \
+    case $b in -*) echo \"base: refusing option-shaped base '$b'\" >&2; return 1;; esac; \
+    echo \"$b\"; \
+  }; f"
+
+  # Remove branches whose changes are already in the base branch, including ones merged via
+  # "Rebase and merge" (which rewrites SHAs, so `git branch --merged` misses them). `git cherry`
+  # compares by patch-id. Takes an optional base, resolving it with `git base` otherwise.
   #
-  # The base is read from origin/HEAD, falling back to whichever of main or
-  # master exists. It must never be hardcoded: `git cherry` prints nothing to
-  # stdout when its upstream does not resolve, so an emptiness test against a
-  # wrong base reads as "fully merged" and force-deletes every branch.
+  # Squash merges are only caught when the branch held a single commit; delete the rest by hand.
+  #
+  # Every way a comparison can fail has to skip the branch rather than delete it. `git cherry`
+  # prints nothing to stdout when its upstream does not resolve, so an emptiness test alone reads a
+  # failed comparison as "fully merged" and force-deletes unmerged work — this once wiped every
+  # branch in a master-based repository. Hence the exit-code check, the abort when no base resolves,
+  # and the fully qualified refs: a bare `main` resolves to `refs/tags/main` before `refs/heads/`,
+  # so a same-named tag makes `git cherry` answer about the tag's history — exiting 0 and reporting
+  # a branch as merged when it is not. Refs are also matched by exact name, against a separate
+  # hazard: `git show-ref --verify` resolves through the filesystem and answers for
+  # `refs/heads/Main` on a case-insensitive volume. Do not collapse any of it back into a pipe to
+  # grep.
+  #
+  # Branches carrying merge commits are skipped as well, since `git cherry` ignores merges and a
+  # conflict resolution living only in one would read as merged and be deleted. Three branches are
+  # never candidates: the base being compared against, the current one, and the repository's own
+  # base branch — `git cleanup develop` would otherwise eat a main that develop contains.
   cleanup = "!f() { \
-    base=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||'); \
-    if [ -z \"$base\" ]; then for c in main master; do git show-ref --verify --quiet \"refs/heads/$c\" && { base=$c; break; }; done; fi; \
-    if [ -z \"$base\" ]; then echo 'cleanup: cannot determine the base branch; aborting' >&2; return 1; fi; \
-    if git show-ref --verify --quiet \"refs/heads/$base\"; then ref=$base; \
-    elif git show-ref --verify --quiet \"refs/remotes/origin/$base\"; then ref=origin/$base; \
+    base=$1; \
+    if [ -z \"$base\" ]; then base=$(git base) || return 1; fi; \
+    keep=$(git base 2>/dev/null); \
+    if [ \"$(git for-each-ref --format='%(refname)' \"refs/heads/$base\")\" = \"refs/heads/$base\" ]; then ref=refs/heads/$base; label=$base; \
+    elif [ \"$(git for-each-ref --format='%(refname)' \"refs/remotes/origin/$base\")\" = \"refs/remotes/origin/$base\" ]; then ref=refs/remotes/origin/$base; label=origin/$base; \
     else echo \"cleanup: base branch '$base' not found locally or on origin; aborting\" >&2; return 1; fi; \
-    cur=$(git symbolic-ref --quiet --short HEAD); \
-    echo \"cleanup: comparing against $ref\"; \
-    git branch --format='%(refname:short)' | while read -r b; do \
-      if [ \"$b\" = \"$base\" ] || [ \"$b\" = \"$cur\" ]; then continue; fi; \
-      if ! out=$(git cherry \"$ref\" \"$b\" 2>/dev/null); then echo \"cleanup: skipping $b (cannot compare)\" >&2; continue; fi; \
-      if ! printf '%s' \"$out\" | grep -q '^+'; then git branch -D \"$b\"; fi; \
+    cur=$(git symbolic-ref --quiet HEAD); \
+    echo \"cleanup: comparing against $label\"; \
+    git for-each-ref --format='%(refname)' refs/heads/ | while read -r r; do \
+      if [ \"$r\" = \"refs/heads/$base\" ] || [ \"$r\" = \"refs/heads/$keep\" ] || [ \"$r\" = \"$cur\" ]; then continue; fi; \
+      b=${r#refs/heads/}; \
+      if ! out=$(git cherry \"$ref\" \"$r\" 2>/dev/null); then echo \"cleanup: skipping $b (cannot compare)\" >&2; continue; fi; \
+      if printf '%s' \"$out\" | grep -q '^+'; then continue; fi; \
+      if [ \"$(git rev-list --count --min-parents=2 \"$ref..$r\")\" != 0 ]; then echo \"cleanup: skipping $b (unique merge commits)\" >&2; continue; fi; \
+      git branch -D -- \"$b\"; \
     done; \
   }; f"
-  pc = "!f() { git pull && git cleanup; }; f"
+  # Pull the current branch, then prune whatever that merged. Takes the same optional base.
+  pc = "!f() { git pull && git cleanup \"$@\"; }; f"
 
   # list of deleted files:
   # git log --diff-filter=D --summary | grep delete


### PR DESCRIPTION
Fixes #83.

`git cleanup` was fixed in #82, but `bclean` still carried the identical bug and `bdone` avoided it only by accident. Run bare in a master-based repository, `git bclean` force-deleted every local branch — the same incident #82 describes, one alias over.

## Summary

- Add a `git base` alias that resolves the repository's base branch from origin/HEAD, falling back to whichever of main or master exists locally or on origin, and fails loudly when none does
- Give `cleanup` an optional base argument and have it consult `git base` when given none; `bclean` becomes a thin wrapper around `cleanup`, `bdone` resolves its checkout target the same way, and `pc` forwards its argument through, so the dangerous comparison has one implementation rather than four
- Pass fully qualified refs to `git cherry` — a tag sharing the base branch's name shadowed the branch and made unmerged work compare clean under a bare `main`, which the exit-code guard could not catch because the command *succeeds*
- **Match refs by exact name instead of `git show-ref --verify`** — its loose-ref lookup resolves through the filesystem, so on a case-insensitive volume it answers for `refs/heads/Main` when asked about `refs/heads/main` while the `for-each-ref` enumeration compares as a string. The base branch fell through every guard between them. See below
- Skip branches carrying merge commits, since `git cherry` ignores merges and a conflict resolution living only inside one would read as merged and be deleted
- Never delete the repository's own base branch, alongside the existing current-branch protection — `git cleanup develop` previously ate a `main` that develop contained
- **Reject an option-shaped base in `bdone`, and give `git checkout` a `--`** — quoting stops word-splitting but not option parsing, so `git bdone -f` reached `git checkout -f`; and the option guard does nothing about a *path*-shaped argument, so `git bdone .` restored every tracked file from the index. Both discarded uncommitted work with no prompt
- **Forward `pc`'s argument to `cleanup`** — it was the one alias in the group that silently ignored the base it was given, so `git pc develop` pulled and then cleaned against `main`
- **Resolve `com` through `git base`, and have it reject arguments** — it was the last hardcoded `main` in the file, so `git com` simply failed in a master-based repo. Making it a function also closes a hazard of its own: git appends arguments to aliases, so `git com notes.md` ran `git checkout main notes.md` and silently reverted that file. It now refuses any argument rather than reporting success while ignoring it, which is what every sibling alias already did
- **Refuse an option-shaped base at the source** — `git base` validates the name it emits, so all four consumers inherit it. A remote whose default branch is named `-f` otherwise reaches `git checkout` as a flag, where `--` stops a pathspec but not an option
- **Verify `origin/HEAD` still resolves in `git base`** — `git up` prunes remote refs, so a renamed or deleted upstream left a dangling symref that was reported as a base with exit 0, contradicting the alias's own promise to fail when none resolves
- Iterate with `git for-each-ref refs/heads/`, dropping the `(HEAD detached at …)` pseudo-entry that produced a confusing skip message
- Keep the comments to what the aliases *do*; the reasoning behind each guard lives in the commit message rather than the file

`git bclean ""` is fixed as a side effect of the rewrite: `${1-main}` substituted only when the argument was unset, so an explicit empty string became a base named `""`.

## The case-sensitivity defect

Caught by expert review after the first version of this branch, and reproduced twice before fixing. It is the same hazard this PR exists to kill — *two ways of naming a ref that don't agree* — in a third disguise.

No user error is required. A repository whose base branch is named `Main`:

```console
$ git cleanup
cleanup: comparing against main
Deleted branch Main (was a9eb777).     # the base branch, force-deleted
```

And with a plausible typo, the blast radius reaches unpushed work:

```console
$ git cleanup DEVELOP                  # develop has unpushed commits
cleanup: comparing against DEVELOP
Deleted branch develop (was 3b8e5bf).  # reachable from no ref; reflog only
```

The fault **disappears when refs are packed**, so it presents intermittently — `git gc` packs them, the next `git branch` creates a loose one again. Matching by exact refname also makes base resolution glob-proof: `git cleanup 'ma*'` now aborts instead of silently matching `main`.

Worth noting that the blast radius in the first case stopped at one branch *because* of the exit-code guard this PR adds — with the base ref gone, `git cherry` failed and every remaining branch was skipped rather than deleted.

## Squash-merge coverage, corrected

The comments claimed branches merged via "Squash and merge" are cleaned up. That only holds when the branch held a **single** commit: a squash collapses N commits into one whose combined patch-id matches none of the originals, so `git cherry` reports every commit as unmerged. Measured at N = 1, 2, 3, 5 — only N=1 is detected.

This errs toward keeping work, so the comment now records the limit rather than promising coverage. Widening the test means comparing the branch's combined diff patch-id against every commit in the base, which measured ~14 ms per commit scanned — minutes on a real repository, and not worth it inside an interactive alias.

## Test plan

Verified with a harness that extracts only the `[alias]` section into a throwaway `GIT_CONFIG_GLOBAL` (with `GIT_CONFIG_SYSTEM=/dev/null` and a scratch `HOME`) and exercises each scenario against real bare-origin clones.

- [x] `git bclean` in a master-based repository resolves master and keeps unmerged branches (the filed bug)
- [x] `git bclean ""` falls through to resolution instead of treating the empty string as a base
- [x] `git bclean typo-brnch` aborts with exit 1 and deletes nothing
- [x] A tag named `main` no longer masks unmerged work, and no longer produces a spurious base-branch error
- [x] `git bdone` resolves master in a master-based repository and checks it out
- [x] `git bdone develop` honors the explicit base and leaves `main` intact
- [x] Regressions from #82 all still pass: normal main-based repo, no origin remote, base only on origin, no base resolvable (aborts, exit 1), detached HEAD, current branch never deleted, worktree-held branch survives while the loop continues
- [x] A branch whose only unique content is a conflict-resolution merge is skipped rather than deleted
- [x] A `refs/heads/-D` branch reaches no `git branch -D` unquoted — no option injection
- [x] `git base` prints the base on stdout and fails silently there when none resolves
- [x] All alias bodies parse under `dash -n` and `sh -n`
- [x] **A base branch named `Main` survives `git cleanup` on a case-insensitive volume**
- [x] **`git cleanup DEVELOP` aborts instead of deleting `develop`**
- [x] **`git cleanup 'ma*'` aborts instead of matching `main`**
- [x] `git bdone -f`, `--force`, `--`, `-`, and `--hard` abort with `bdone: invalid base`, and the uncommitted edit survives
- [x] `git bdone .`, `git bdone '*'`, `git bdone notes.md`, and `git bdone src` leave the worktree untouched — the `--` closes the pathspec route
- [x] `--` does not break legitimate use: bare `git bdone` switches and prunes, `git bdone develop` honors the explicit base, and a base existing only on origin still DWIMs into a tracking branch
- [x] `git pc` short-circuits on a failed pull and never reaches `cleanup`
- [x] `git com` resolves `main`, `master`, and an `origin/HEAD`-designated `develop`; aborts with HEAD unmoved when no base resolves; DWIMs an origin-only base
- [x] `git com <anything>` — `develop`, `notes.md`, `.`, `*`, `-f`, `main` — is rejected with `com: takes no arguments`, HEAD unmoved, worktree untouched
- [x] Cloning a remote whose default branch is named `-f`: `git base` refuses it, and `git com` / `git bdone` therefore never reach `git checkout -f` — uncommitted work survives
- [x] `git pc develop` reports `comparing against develop`; bare `git pc` still resolves the base
- [x] A dangling `origin/HEAD` falls back to `main`; with no fallback available `git base` fails cleanly instead of returning the ghost name; a valid `origin/HEAD` still takes precedence
- [x] **Three rounds of independent expert review**, each against disposable repos with baselines built from the previous definitions: round one found the case-sensitivity data loss; round two verified the fixes at 83/83 and found the `bdone` pathspec hole; round three verified those and found the option-shaped base and `com`'s silent argument. Every finding is fixed above, and the final state passes a further 21/21 including the hostile-remote chain. (One agent in round three died on an API error, so that round is two reports rather than three.)

### Known and accepted

- The exit status on the delete path is the last loop iteration's, since the `while` remains the last stage of a pipeline — so a `git branch -D` that fails mid-loop is only reflected in the return code when it sorts last. Unchanged by this PR, noted in #83 as non-blocking; git still prints the error to stderr either way.
- When `git base` cannot resolve, `keep` is empty and the "never delete the repository's own base" protection lapses. Bounded: a branch with commits not in the given base is still reported `+` by `git cherry` and skipped, so what is lost is a branch pointer already reachable from the base, never commits.
- With `main` packed and `Main` loose on a case-insensitive volume, `cleanup` can still delete `Main`. Identical on `main` and rooted in git's own resolution — `git rev-parse refs/heads/main` already returns the wrong SHA in that state.
- Squash merges are only detected for single-commit branches, as documented above.
