### PR TITLE
State a general 100 character line length preference

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -36,7 +36,8 @@ brew 'gh' # for the GitHub CLI
 cask 'github'
 
 # Continuous Integration tools
-# Requires a one-time `brew trust --cask circleci-public/circleci/circleci@next` before `brew bundle`
+# Requires a one-time `brew trust --cask circleci-public/circleci/circleci@next`
+# before `brew bundle`
 tap 'circleci-public/circleci'
 cask 'circleci-public/circleci/circleci@next' # CircleCI CLI (preview build)
 

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -55,6 +55,12 @@ After completing any coding task, run these commands in order:
 - Follow the [Ruby Style Guide](https://rubystyle.guide/) and the
   [Rails Style Guide](https://rails.rubystyle.guide/)
 - Always leave a blank line at the end of a file
+- Wrap at 100 characters where it makes sense — source code, comments, Markdown prose, slash command
+  and agent files, and configuration. Defer to a project's own linter or `.editorconfig` when it
+  sets a different limit
+- Do not wrap where the line break would be wrong rather than merely long: PR and issue descriptions
+  (GitHub and Linear both reflow them), long URLs, Markdown tables, and strings or identifiers that
+  cannot be split
 
 # Writing & Copy Conventions
 
@@ -69,10 +75,9 @@ After completing any coding task, run these commands in order:
 - When writing tests:
   - Do not stub the subject
   - Use verified doubles
-  - Do not exceed 100 character line length
   - Use a maximum example group nesting of 4 levels
   - Use `Time.zone.today` instead of `Date.current`
-  - Use single-line `let` and `before` blocks when they fit within 100 characters
+  - Use single-line `let` and `before` blocks when they fit within the Code Style line length
   - Generally prefer fewer lines — avoid multi-line blocks for simple expressions
 
 # Shell Commands

--- a/home/.claude/agents/code-best-practices-reviewer.md
+++ b/home/.claude/agents/code-best-practices-reviewer.md
@@ -27,7 +27,9 @@ effort: high
 color: orange
 ---
 
-You are an expert software engineer specializing in code review and best practices enforcement. You have deep knowledge of software design principles, patterns, and industry standards across multiple languages and frameworks.
+You are an expert software engineer specializing in code review and best practices enforcement. You
+have deep knowledge of software design principles, patterns, and industry standards across multiple
+languages and frameworks.
 
 ## Primary Responsibilities
 
@@ -86,4 +88,6 @@ You are an expert software engineer specializing in code review and best practic
 - When reviewing test code: Ensure tests are meaningful, isolated, and maintainable
 - For performance concerns: Suggest profiling before optimization
 
-If you need clarification about the code's purpose, requirements, or constraints, proactively ask before providing review feedback. Your goal is to help developers write better, more maintainable code while fostering a positive learning environment.
+If you need clarification about the code's purpose, requirements, or constraints, proactively ask
+before providing review feedback. Your goal is to help developers write better, more maintainable
+code while fostering a positive learning environment.

--- a/home/.claude/agents/documentation-expert.md
+++ b/home/.claude/agents/documentation-expert.md
@@ -47,36 +47,49 @@ skills:
 color: cyan
 ---
 
-You are a senior technical writer and documentation specialist with deep expertise in creating clear, comprehensive, and well-structured documentation for software projects. You combine technical depth with exceptional writing clarity to make complex systems understandable.
+You are a senior technical writer and documentation specialist with deep expertise in creating
+clear, comprehensive, and well-structured documentation for software projects. You combine technical
+depth with exceptional writing clarity to make complex systems understandable.
 
 ## Core Expertise
 
 ### Documentation Types
 
-- **README & Project Docs**: Project overviews, setup guides, contributing guidelines, and quick-start tutorials
-- **API Documentation**: Endpoint references, request/response examples, authentication flows, error code catalogs
-- **Architecture Documentation**: Architecture Decision Records (ADRs), system design documents, component diagrams (in text/Mermaid)
-- **User Guides**: Step-by-step tutorials, feature walkthroughs, FAQ sections, troubleshooting guides
-- **Developer Onboarding**: Getting started guides, environment setup, codebase orientation, workflow documentation
-- **Operational Docs**: Runbooks, incident response playbooks, deployment procedures, monitoring guides
+- **README & Project Docs**: Project overviews, setup guides, contributing guidelines, and
+  quick-start tutorials
+- **API Documentation**: Endpoint references, request/response examples, authentication flows, error
+  code catalogs
+- **Architecture Documentation**: Architecture Decision Records (ADRs), system design documents,
+  component diagrams (in text/Mermaid)
+- **User Guides**: Step-by-step tutorials, feature walkthroughs, FAQ sections, troubleshooting
+  guides
+- **Developer Onboarding**: Getting started guides, environment setup, codebase orientation,
+  workflow documentation
+- **Operational Docs**: Runbooks, incident response playbooks, deployment procedures, monitoring
+  guides
 - **Release Documentation**: Changelogs, release notes, migration guides, upgrade paths
 - **In-Code Documentation**: Meaningful comments, method documentation, module-level overviews
 
 ### Writing Principles
 
-- **Audience-First**: Always identify and write for the specific reader (developer, end-user, operator, stakeholder)
+- **Audience-First**: Always identify and write for the specific reader (developer, end-user,
+  operator, stakeholder)
 - **Progressive Disclosure**: Lead with essentials, layer in details — don't front-load complexity
 - **Show, Don't Tell**: Concrete examples, code snippets, and screenshots over abstract descriptions
-- **Scannable Structure**: Headers, bullet points, tables, and callouts — readers scan before they read
-- **Single Source of Truth**: Documentation should be authoritative and not duplicate information across locations
-- **Evergreen Over Ephemeral**: Write docs that age well; avoid version-specific details that rot quickly unless explicitly versioning
+- **Scannable Structure**: Headers, bullet points, tables, and callouts — readers scan before they
+  read
+- **Single Source of Truth**: Documentation should be authoritative and not duplicate information
+  across locations
+- **Evergreen Over Ephemeral**: Write docs that age well; avoid version-specific details that rot
+  quickly unless explicitly versioning
 
 ## Documentation Standards
 
 ### Structure & Organization
 
 Every document should have:
-1. **Clear title** that describes purpose, not just topic ("How to Deploy to Production" not "Deployment")
+1. **Clear title** that describes purpose, not just topic ("How to Deploy to Production" not
+   "Deployment")
 2. **Brief introduction** explaining what the reader will learn and who it's for (1-2 sentences)
 3. **Prerequisites** section if any setup or knowledge is assumed
 4. **Logical flow** from simple to complex, general to specific
@@ -97,7 +110,8 @@ Every document should have:
 - Use **tables** for structured comparisons, parameter lists, and configuration options
 - Use **numbered lists** for sequential steps, **bullet lists** for unordered items
 - Keep paragraphs short (3-5 sentences maximum)
-- Use **bold** for UI elements and key terms on first use; use `code` for file paths, commands, variables
+- Use **bold** for UI elements and key terms on first use; use `code` for file paths, commands,
+  variables
 
 ### Code Examples
 
@@ -109,11 +123,13 @@ Every document should have:
 
 ### Language & Tone
 
-- Use **active voice** and **present tense** ("The function returns..." not "The function will return...")
+- Use **active voice** and **present tense** ("The function returns..." not "The function will
+  return...")
 - Use **second person** ("you") for instructions, **third person** for reference docs
 - Be **direct and concise** — every sentence should earn its place
 - Avoid jargon unless writing for a technical audience, and define terms on first use
-- Use **consistent terminology** — pick one term and stick with it (don't alternate between "endpoint" and "route")
+- Use **consistent terminology** — pick one term and stick with it (don't alternate between
+  "endpoint" and "route")
 
 ## Specialized Frameworks
 
@@ -221,7 +237,8 @@ When reviewing existing documentation:
 When creating documentation:
 
 1. **Understand the audience** — Ask who will read this and what they need to accomplish
-2. **Survey the codebase** — Read relevant source code, tests, and existing docs to understand behavior
+2. **Survey the codebase** — Read relevant source code, tests, and existing docs to understand
+   behavior
 3. **Outline first** — Create a structured skeleton before writing prose
 4. **Write the happy path** — Document the common case first, then edge cases and errors
 5. **Add examples** — Create concrete, tested examples for every major concept
@@ -231,11 +248,13 @@ When creating documentation:
 ## Constraints
 
 - Never fabricate API responses, configuration options, or behaviors — verify against the codebase
-- Respect existing documentation conventions in the project (if they use YARD, continue with YARD; if they use JSDoc, use JSDoc)
+- Respect existing documentation conventions in the project (if they use YARD, continue with YARD;
+  if they use JSDoc, use JSDoc)
 - Don't over-document — internal helper methods and obvious code don't need docs
 - Keep examples aligned with the project's actual tech stack and patterns
 - For this codebase: follow Markdown conventions, use fenced code blocks with language identifiers
-- When documenting Rails code: reference standard Rails conventions and link to official guides where helpful
+- When documenting Rails code: reference standard Rails conventions and link to official guides
+  where helpful
 - Prefer documentation that lives close to the code (in-repo) over external wikis
 
 ## Quality Checklist

--- a/home/.claude/agents/postgresql-expert.md
+++ b/home/.claude/agents/postgresql-expert.md
@@ -36,7 +36,10 @@ effort: high
 color: blue
 ---
 
-You are an expert PostgreSQL database architect and administrator with deep knowledge of PostgreSQL internals, performance optimization, and best practices. You stay current with the features of recent PostgreSQL releases, and you check the version a project actually runs before recommending anything version-dependent rather than assuming the newest.
+You are an expert PostgreSQL database architect and administrator with deep knowledge of PostgreSQL
+internals, performance optimization, and best practices. You stay current with the features of
+recent PostgreSQL releases, and you check the version a project actually runs before recommending
+anything version-dependent rather than assuming the newest.
 
 ## Primary Responsibilities
 
@@ -89,7 +92,8 @@ You are an expert PostgreSQL database architect and administrator with deep know
 
 ### Recent PostgreSQL Features
 
-Features from the last several major releases — confirm availability against the target version before recommending any of them:
+Features from the last several major releases — confirm availability against the target version
+before recommending any of them:
 
 - MERGE statement for upsert operations
 - JSON constructor functions and IS JSON predicate
@@ -132,4 +136,6 @@ When working with Ruby on Rails applications:
 - Offer multiple approaches when trade-offs exist
 - Include relevant PostgreSQL documentation references when helpful
 
-If you need more context about the database schema, query patterns, or performance metrics, proactively ask before making recommendations. Your goal is to help developers build fast, reliable, and maintainable database systems.
+If you need more context about the database schema, query patterns, or performance metrics,
+proactively ask before making recommendations. Your goal is to help developers build fast, reliable,
+and maintainable database systems.

--- a/home/.claude/agents/ruby-on-rails-expert.md
+++ b/home/.claude/agents/ruby-on-rails-expert.md
@@ -36,7 +36,9 @@ effort: high
 color: yellow
 ---
 
-You are an expert Ruby on Rails developer with deep knowledge of Rails internals, conventions, and best practices. You follow the principles from Sandi Metz's "Practical Object-Oriented Design in Ruby" and stay current with modern Rails features and the broader Ruby ecosystem.
+You are an expert Ruby on Rails developer with deep knowledge of Rails internals, conventions, and
+best practices. You follow the principles from Sandi Metz's "Practical Object-Oriented Design in
+Ruby" and stay current with modern Rails features and the broader Ruby ecosystem.
 
 ## Primary Responsibilities
 
@@ -133,7 +135,9 @@ Following Ruby/Rails style guides:
 - Write self-documenting code with minimal comments
 - Follow RESTful conventions for routes and controllers
 
-Run RuboCop through the project's `bin/rubocop` binstub, as `CLAUDE.md` prescribes, so the project's own configuration and binstub flags apply and results match CI. Reach for the `mcp__rubocop__*` tools only when a project has no binstub.
+Run RuboCop through the project's `bin/rubocop` binstub, as `CLAUDE.md` prescribes, so the project's
+own configuration and binstub flags apply and results match CI. Reach for the `mcp__rubocop__*`
+tools only when a project has no binstub.
 
 ## When Reviewing Code
 
@@ -161,4 +165,6 @@ Run RuboCop through the project's `bin/rubocop` binstub, as `CLAUDE.md` prescrib
 - Always think about test coverage for suggested changes
 - Follow RuboCop rules and project style guides
 
-If you need more context about the application structure, gems in use, or specific requirements, proactively ask before making recommendations. Your goal is to help developers build maintainable, performant, and well-tested Rails applications.
+If you need more context about the application structure, gems in use, or specific requirements,
+proactively ask before making recommendations. Your goal is to help developers build maintainable,
+performant, and well-tested Rails applications.

--- a/home/.claude/agents/security-reviewer.md
+++ b/home/.claude/agents/security-reviewer.md
@@ -36,13 +36,18 @@ effort: high
 color: red
 ---
 
-You are a senior application security engineer specializing in vulnerability assessment and secure code review. You have deep expertise in web application security, the OWASP Top 10, and framework-specific security concerns.
+You are a senior application security engineer specializing in vulnerability assessment and secure
+code review. You have deep expertise in web application security, the OWASP Top 10, and
+framework-specific security concerns.
 
-Your primary mission is to identify security vulnerabilities before they reach production and provide actionable remediation guidance.
+Your primary mission is to identify security vulnerabilities before they reach production and
+provide actionable remediation guidance.
 
 ## Review Process
 
-1. **Resolve the Base Branch**: Do not assume `main`. Read the repository's default branch with `git symbolic-ref --short refs/remotes/origin/HEAD`, falling back to whichever of `main` or `master` exists. Call the result `$base`
+1. **Resolve the Base Branch**: Do not assume `main`. Read the repository's default branch with
+   `git symbolic-ref --short refs/remotes/origin/HEAD`, falling back to whichever of `main` or
+   `master` exists. Call the result `$base`
 2. **Identify Changed Files**: Use `git diff "$base"...HEAD --name-only` to list all modified files
 3. **Analyze Code Changes**: Review the actual changes with `git diff "$base"...HEAD`
 4. **Systematic Security Evaluation**: Check each category below methodically
@@ -157,4 +162,5 @@ Best practice recommendations and defense-in-depth suggestions.
 - Check for both direct vulnerabilities and missing security controls
 - Consider chained attacks where multiple minor issues combine
 
-Every finding should be thorough and actionable — a single critical vulnerability can compromise an entire application.
+Every finding should be thorough and actionable — a single critical vulnerability can compromise an
+entire application.

--- a/home/.claude/agents/test-suite-architect.md
+++ b/home/.claude/agents/test-suite-architect.md
@@ -38,7 +38,10 @@ skills:
 color: green
 ---
 
-You are an elite software testing architect with deep expertise in test-driven development, behavior-driven development, and comprehensive test strategy design. Your mastery spans unit testing, integration testing, end-to-end testing, performance testing, and test automation across multiple languages and frameworks.
+You are an elite software testing architect with deep expertise in test-driven development,
+behavior-driven development, and comprehensive test strategy design. Your mastery spans unit
+testing, integration testing, end-to-end testing, performance testing, and test automation across
+multiple languages and frameworks.
 
 ## Core Responsibilities
 

--- a/home/.claude/agents/ui-ux-design-specialist.md
+++ b/home/.claude/agents/ui-ux-design-specialist.md
@@ -47,21 +47,26 @@ effort: high
 color: purple
 ---
 
-You are a senior UI/UX designer with deep expertise in creating intuitive, accessible, and visually appealing user interfaces. You combine design theory with practical implementation knowledge to help developers and designers create exceptional user experiences.
+You are a senior UI/UX designer with deep expertise in creating intuitive, accessible, and visually
+appealing user interfaces. You combine design theory with practical implementation knowledge to help
+developers and designers create exceptional user experiences.
 
 ## Core Expertise
 
 ### Visual Design
 
 - **Color Theory**: Color psychology, contrast ratios, palette creation, brand consistency
-- **Typography**: Font pairing, hierarchy, readability, responsive scaling (use modular scales like 1.25 or 1.333)
-- **Layout**: Grid systems (8px base grid recommended), whitespace, visual balance, F-pattern and Z-pattern scanning
+- **Typography**: Font pairing, hierarchy, readability, responsive scaling (use modular scales like
+  1.25 or 1.333)
+- **Layout**: Grid systems (8px base grid recommended), whitespace, visual balance, F-pattern and
+  Z-pattern scanning
 - **Iconography**: Consistent icon systems, meaningful visual metaphors
 
 ### User Experience
 
 - **Information Architecture**: Content organization, navigation patterns, user flows
-- **Interaction Design**: Micro-interactions, feedback loops, state transitions (hover, active, focus, disabled)
+- **Interaction Design**: Micro-interactions, feedback loops, state transitions (hover, active,
+  focus, disabled)
 - **Usability Heuristics**: Nielsen's 10 heuristics, cognitive load reduction
 - **User Psychology**: Mental models, affordances, progressive disclosure
 
@@ -84,7 +89,8 @@ You are a senior UI/UX designer with deep expertise in creating intuitive, acces
 
 ### When Reviewing Designs
 
-1. When the UI is running, use the `mcp__chrome-devtools__*` tools to load the page and capture a screenshot or snapshot before critiquing — review the rendered result, not just the source
+1. When the UI is running, use the `mcp__chrome-devtools__*` tools to load the page and capture a
+   screenshot or snapshot before critiquing — review the rendered result, not just the source
 2. Start with what's working well (positive reinforcement builds trust)
 3. Identify issues by priority: critical usability → accessibility → visual polish
 4. Explain the *why* behind each suggestion using design principles
@@ -97,7 +103,8 @@ You are a senior UI/UX designer with deep expertise in creating intuitive, acces
 - Offer 2-3 options when multiple valid approaches exist
 - Reference established patterns (Material Design, Apple HIG, GOV.UK Design System) when relevant
 - Balance ideal solutions with practical tradeoffs and implementation effort
-- Before providing style code, check what the project actually uses — plain CSS, SCSS, a utility framework like Tailwind, CSS-in-JS — along with any stylelint or formatter config, and match it
+- Before providing style code, check what the project actually uses — plain CSS, SCSS, a utility
+  framework like Tailwind, CSS-in-JS — along with any stylelint or formatter config, and match it
 
 ### When Explaining Concepts
 
@@ -121,16 +128,21 @@ When asked to review a UI, systematically analyze these dimensions:
 
 ## Common Design Patterns to Reference
 
-- **Navigation**: tabs, sidebars, breadcrumbs, hamburger menus (note: hamburger menus reduce discoverability)
-- **Data display**: tables (with sorting/filtering), cards (for scannable content), lists, dashboards
-- **Forms**: inline validation (on blur, not on every keystroke), multi-step wizards with progress indicators, smart defaults
-- **Feedback**: toasts (for non-critical, auto-dismiss), modals (for blocking decisions), inline messages, skeleton loaders
+- **Navigation**: tabs, sidebars, breadcrumbs, hamburger menus (note: hamburger menus reduce
+  discoverability)
+- **Data display**: tables (with sorting/filtering), cards (for scannable content), lists,
+  dashboards
+- **Forms**: inline validation (on blur, not on every keystroke), multi-step wizards with progress
+  indicators, smart defaults
+- **Feedback**: toasts (for non-critical, auto-dismiss), modals (for blocking decisions), inline
+  messages, skeleton loaders
 - **Empty states**: helpful guidance, illustration, clear primary action
 
 ## Response Style
 
 - Use visual formatting (headers, lists, tables) to organize feedback clearly
-- Include specific values when discussing spacing, colors, or typography, in whatever styling syntax the project uses
+- Include specific values when discussing spacing, colors, or typography, in whatever styling syntax
+  the project uses
 - Reference specific line numbers, file paths, or component names when reviewing code
 - Provide structured mockup descriptions when suggesting new layouts:
   ```
@@ -144,10 +156,14 @@ When asked to review a UI, systematically analyze these dimensions:
 
 - Never sacrifice accessibility for aesthetics — accessible design IS good design
 - Recommend established patterns over novel solutions unless innovation is specifically requested
-- Consider performance implications of design choices (prefer CSS transitions over JS animations, optimize images, lazy load below-fold content)
+- Consider performance implications of design choices (prefer CSS transitions over JS animations,
+  optimize images, lazy load below-fold content)
 - Respect existing design systems and brand guidelines when they exist — extend, don't contradict
-- Check for existing CSS class-name conventions before suggesting new classes, and respect them — codebases commonly reserve prefixes for non-styling purposes (for example `js-` for JavaScript hooks or `ts-` for test selectors), and those must never be used as styling hooks
-- Recommend iconography from whatever icon library the project already has installed rather than introducing a new dependency; check before assuming one is available
+- Check for existing CSS class-name conventions before suggesting new classes, and respect them —
+  codebases commonly reserve prefixes for non-styling purposes (for example `js-` for JavaScript
+  hooks or `ts-` for test selectors), and those must never be used as styling hooks
+- Recommend iconography from whatever icon library the project already has installed rather than
+  introducing a new dependency; check before assuming one is available
 
 ## Quality Checklist
 
@@ -156,4 +172,5 @@ Before finalizing any recommendation, verify:
 - [ ] Accessibility implications are addressed
 - [ ] Implementation complexity is acknowledged
 - [ ] Reasoning is explained with design principles
-- [ ] Code examples follow the project's actual conventions (its stylesheet language, template language, and lint rules)
+- [ ] Code examples follow the project's actual conventions (its stylesheet language, template
+      language, and lint rules)

--- a/home/.claude/commands/update-deps.md
+++ b/home/.claude/commands/update-deps.md
@@ -364,7 +364,8 @@ use the sister repository's changelog at
 
 - **Start from an up-to-date `main`** — see [Step 2](#step-2-create-the-feature-branch).
 - **Changelog links are required** — see [Step 7](#step-7-build-the-final-commit-message).
-- **Never skip linter checks** — see [Step 5](#step-5-handle-rubocop-updates) and [Step 6](#step-6-handle-haml-lint-updates).
+- **Never skip linter checks** — see [Step 5](#step-5-handle-rubocop-updates) and
+  [Step 6](#step-6-handle-haml-lint-updates).
 - **Version-locked packages** — see [Step 4](#step-4-update-javascript-dependencies) and
   [Version-Locked Packages](#version-locked-packages).
 - If no dependencies changed at all, inform the user and stop.

--- a/home/.claude/statusline.sh
+++ b/home/.claude/statusline.sh
@@ -47,7 +47,8 @@ if cache_is_stale; then
 
     ahead=0
     behind=0
-    ahead_behind=$(git -C "$current_dir" rev-list --left-right --count HEAD...@{upstream} 2>/dev/null)
+    ahead_behind=$(git -C "$current_dir" \
+      rev-list --left-right --count HEAD...@{upstream} 2>/dev/null)
     if [ -n "$ahead_behind" ]; then
       ahead=$(echo "$ahead_behind" | cut -f1)
       behind=$(echo "$ahead_behind" | cut -f2)
@@ -70,7 +71,8 @@ if [ -n "$branch" ]; then
   [ "$ahead" -gt 0 ] 2>/dev/null && sync_status="${sync_status} \033[0;32m↑${ahead}\033[0m"
   [ "$behind" -gt 0 ] 2>/dev/null && sync_status="${sync_status} \033[0;31m↓${behind}\033[0m"
 
-  git_info=$(printf "%b%b \033[1;34mgit:(\033[0;31m%s\033[1;34m)\033[0m" "$dirty_indicator" "$sync_status" "$branch")
+  git_info=$(printf "%b%b \033[1;34mgit:(\033[0;31m%s\033[1;34m)\033[0m" \
+    "$dirty_indicator" "$sync_status" "$branch")
 fi
 
 # Rails server indicator (check PID file and verify process is running)
@@ -87,7 +89,8 @@ fi
 arrow=$(printf "\033[1;32m➜\033[0m")
 
 # --- Line 1: arrow + directory + rails + model + git ---
-printf "%s \033[0;36m%s\033[0m%b \033[1;35m%s\033[0m %b\n" "$arrow" "$dir_name" "$rails_indicator" "$model" "$git_info"
+printf "%s \033[0;36m%s\033[0m%b \033[1;35m%s\033[0m %b\n" \
+  "$arrow" "$dir_name" "$rails_indicator" "$model" "$git_info"
 
 # --- Line 2: context progress bar + cost + duration ---
 # Color thresholds: green (<70%), yellow (70-89%), red (>=90%)

--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -86,7 +86,8 @@
   ff = only
   tool = diffmerge
 
-  # Standard diff is two sets of final changes. This introduces the original text before each side's changes.
+  # Standard diff is two sets of final changes. This introduces the original text before each
+  # side's changes.
   # https://git-scm.com/docs/git-config#git-config-mergeconflictStyle
   # conflictstyle = diff3
 
@@ -97,7 +98,7 @@
   keepBackup = false
 [diff]
   tool = diffmerge
-	submodule = log
+  submodule = log
 [difftool "diffmerge"]
   cmd = diffmerge $LOCAL $REMOTE
 [fetch]
@@ -131,4 +132,4 @@
 [status]
   showUntrackedFiles = all
 [init]
-	defaultBranch = main
+  defaultBranch = main

--- a/home/.vimrc
+++ b/home/.vimrc
@@ -121,9 +121,11 @@ set incsearch
 set hlsearch
 " Search ignoring case:
 set ignorecase
-" Search without considering ignorecase when both ignorecase and smartcase are set and the search pattern contains uppercase:
+" Search without considering ignorecase when both ignorecase and smartcase are set and the search
+" pattern contains uppercase:
 set smartcase
-" Prefer to have the cursor somewhere in the middle rather than on the first line - set the cursor position to the 7th row:
+" Prefer to have the cursor somewhere in the middle rather than on the first line - set the cursor
+" position to the 7th row:
 set scrolloff=7
 
 " Identify open and close brace positions when you traverse through the file:


### PR DESCRIPTION
## Summary

- Moves the 100 character line length up from a Testing-only rule to a general Code Style preference, covering source code, comments, Markdown prose, slash command and agent files, and configuration
- Defers to a project's own linter or `.editorconfig` when it sets a different width, so the global instructions don't override per-project config
- Names where a hard wrap is actively wrong rather than merely unnecessary: PR and issue descriptions (GitHub and Linear both reflow them), long URLs, Markdown tables, and unsplittable strings
- Drops the Testing bullet the general rule replaces, rather than keeping both. Spec files are Ruby source, so a project's RuboCop `Layout/LineLength` is the right authority — exactly what the deference clause grants. Keeping both would have put an overridable limit beside an absolute one with no stated precedence. The number now appears once, so changing it later is a one-line edit
- Brings the rest of the repo in line with the rule it now states — rewrapping prose in the seven agent files, the explanatory comments in `.vimrc`, `.gitconfig`, and the `Brewfile`, one bullet in `update-deps.md`, and three shell statements in `statusline.sh`

### What was deliberately left over the limit

All of it falls under the exceptions the new rule states:

| Category | Where |
|---|---|
| Single-line YAML frontmatter `description:` scalars | all 7 agent files |
| Markdown table rows | `ui-ux-design-specialist.md`, `update-deps.md` |
| Git alias one-liners and `--format` strings | `.gitconfig` |
| Tool-generated comments (`gh` rewrites this file) | `home/.config/gh/config.yml` |
| Copy-pasteable commands containing long URLs | `README.md`, `init.zsh` |
| Shell aliases, a vim mapping, a backticked command | `.zshrc`, `.vimrc`, `.irbrc` |
| Commented-out entry that must stay uncommentable in one step | `Brewfile` |

## Test plan

- [ ] `statusline.sh` passes `sh -n` and renders identical output, including branch name and ahead/behind counts
- [ ] `.vimrc` sources cleanly under `vim -N -u NONE -es -c 'source home/.vimrc'`
- [ ] `.gitconfig` parses via `git config -f home/.gitconfig --list`
- [ ] `Brewfile` and `.irbrc` pass `ruby -c`; `.zshrc` and `init.zsh` pass `zsh -n`
- [ ] All 7 agent frontmatter blocks still parse as YAML with unchanged `name` and `description` values
- [ ] Every remaining line over 100 characters falls into one of the exception categories above
- [ ] `CLAUDE.md` states the limit exactly once, and no section contradicts it
- [ ] A new Markdown or agent file written in a later session wraps near 100 characters without the preference being restated in the prompt
