### PR TITLE
Fix two broken instructions in the update-deps command

### DIFF
--- a/home/.claude/commands/update-deps.md
+++ b/home/.claude/commands/update-deps.md
@@ -24,7 +24,7 @@ Check whether any `update-dependencies-*` branches already exist for the
 current month:
 
 ```bash
-git branch -r --list "origin/update-dependencies-*-$(date +%B-%Y | tr '[:upper:]' '[:lower:]')"
+git branch -r --list "origin/update-dependencies-*$(date +%B-%Y | tr '[:upper:]' '[:lower:]')"
 ```
 
 **Naming rules:**
@@ -65,11 +65,10 @@ dependency changes:
 gem_update 2>&1 | tee /tmp/gem-update-output.txt
 ```
 
-`gem_update` is a custom gem (installed via `gem install gem_update`) that
-runs `bundle update` internally and outputs a formatted changelog with
-version diffs and changelog links. Capture this output — it will be the
-starting point for the commit message body. If `gem_update` is not
-available, run `bundle update` directly and manually build the changelog
+`gem_update` is the CLI provided by the `gem_updater` gem (installed via `gem install gem_updater`)
+that runs `bundle update` internally and outputs a formatted changelog with version diffs and
+changelog links. Capture this output — it will be the starting point for the commit message body.
+If `gem_update` is not available, run `bundle update` directly and manually build the changelog
 from the `Gemfile.lock` diff.
 
 A successful run prints a list of gem updates with version diffs. If


### PR DESCRIPTION
## Summary

Two steps of the `/update-deps` runbook prescribed something that doesn't work. Both fail quietly rather than loudly, which is likely why they survived — neither surfaces during a normal successful run.

**Step 1 — the branch-existence check never matches a first-of-month branch.** The pattern `update-dependencies-*-<month>-<year>` has a literal hyphen before the month, so the wildcard cannot match nothing. The unqualified name the very next paragraph prescribes (`update-dependencies-august-2026`) is invisible to the check, which then reports that no branch exists and lets the command create a colliding duplicate. Dropping the hyphen lets `*` absorb the optional qualifier along with its trailing separator.

**Step 3 — `gem install gem_update` names a package that doesn't exist.** `gem_update` is the executable; the gem that provides it is `gem_updater`, as this repo's own `home/.rbenv/default-gems` records. Anyone following the documented fallback path would hit `could not find a valid gem 'gem_update'`. Naming the gem and the CLI separately matches how the same file already describes the `haml_lint` gem and its `haml-lint` binary.

The reflowed paragraph adopts the 100 character width these instructions now prescribe. The rest of the file remains at its original narrower wrap — converting it wholesale felt out of scope for a bug fix, but say the word and I'll fold it in.

## Test plan

- [ ] The corrected glob matches all four August branch forms — `update-dependencies-august-2026`, `update-dependencies-early-august-2026`, `update-dependencies-mid-late-august-2026`, `update-dependencies-end-of-august-2026` — verified in a scratch repo
- [ ] The corrected glob still excludes a different month (`update-dependencies-july-2026` does not match the August pattern)
- [ ] `gem install gem_updater` resolves on rubygems.org, and `gem_update` is the binary it installs
- [ ] No line in the touched paragraph exceeds 100 characters
- [ ] The next real `/update-deps` run on the first of a month detects an existing branch instead of creating a duplicate

## Notes

Found during a `/doc-review` pass over the Claude configuration docs. Independent of #87 (line length guidance), which touches a different part of this file and should merge cleanly either way.
