### PR TITLE
Run git cleanup's branch comparisons in parallel

### DIFF
--- a/home/.gitconfig
+++ b/home/.gitconfig
@@ -93,6 +93,38 @@
   # conflict resolution living only in one would read as merged and be deleted. Three branches are
   # never candidates: the base being compared against, the current one, and the repository's own
   # base branch — `git cleanup develop` would otherwise eat a main that develop contains.
+  #
+  # The cost is one `git cherry` per branch, and each one rebuilds a patch-id table covering every
+  # commit the branch is behind the base — so a repository with hundreds of stale branches spends
+  # tens of seconds here. The comparisons are independent, so they run `xargs -P` wide and only
+  # classify; deletion stays serial. Branches are handed over NUL-delimited because a ref name may
+  # contain quotes, which `xargs` would otherwise treat as syntax. The `cleanup-worker` argument
+  # after the `sh -c` script is what `$0` binds to; without it `xargs` binds the first branch of
+  # every batch there instead, where the loop over `$@` never reaches it — one branch in twenty
+  # would go silently uncompared, neither deleted nor reported. All verdicts are collected before
+  # the first deletion so no ref disappears while another process is still walking the ref table.
+  # Workers finish out of order, so the verdicts are sorted by ref name before anything is deleted:
+  # the list of deleted branches is this command's audit trail, and scanning it for a branch you did
+  # not expect to lose is far harder shuffled. An aborted fan-out leaves branches unclassified
+  # rather than unmerged, so a non-zero status there deletes nothing instead of deleting a subset.
+  # Judging every branch against one pre-deletion snapshot is also what makes a symbolic ref under
+  # refs/heads/ decidable at all. Serially its verdict depended on whether its target sorted ahead
+  # of it and had already been deleted, so the same repository kept or removed the alias purely on
+  # name order. They are skipped outright now: a symref is not a branch, and which of the two names
+  # `git branch -D` would take is exactly the kind of question this command should decline. The
+  # reader ignores any verdict whose ref is not under refs/heads/, so a torn or truncated line
+  # cannot reach `git branch -D` as a bare or half-formed name.
+  # The reader re-checks the three protected branches before deleting even though only the filtered
+  # list reaches a worker. Serially those two steps sat in one loop, where "a protected branch can
+  # never reach the delete" was there to read; split apart it becomes a claim about the whole
+  # pipeline, and the recheck costs nothing next to what restoring a wrongly deleted branch costs.
+  #
+  # A merged branch is one whose `git cherry` output holds no `+` line. That is tested by scanning
+  # output words for a bare `+` rather than piping to grep, which saves a process per branch and is
+  # exact only because the output is nothing but `+`/`-` markers and hex object names. Adding `-v`
+  # would put commit subjects in that stream and a subject containing a lone `+` would then read as
+  # unmerged. Keep `git cherry` unadorned. Globbing is off around the scan so that no marker or
+  # object name is expanded against the working tree.
   cleanup = "!f() { \
     base=$1; \
     if [ -z \"$base\" ]; then base=$(git base) || return 1; fi; \
@@ -102,13 +134,45 @@
     else echo \"cleanup: base branch '$base' not found locally or on origin; aborting\" >&2; return 1; fi; \
     cur=$(git symbolic-ref --quiet HEAD); \
     echo \"cleanup: comparing against $label\"; \
-    git for-each-ref --format='%(refname)' refs/heads/ | while read -r r; do \
-      if [ \"$r\" = \"refs/heads/$base\" ] || [ \"$r\" = \"refs/heads/$keep\" ] || [ \"$r\" = \"$cur\" ]; then continue; fi; \
+    jobs=$(getconf _NPROCESSORS_ONLN 2>/dev/null); \
+    case $jobs in ''|*[!0-9]*|0) jobs=4;; esac; \
+    if [ \"$jobs\" -gt 16 ]; then jobs=16; fi; \
+    verdicts=$( \
+      git for-each-ref --format='%(refname) %(symref)' refs/heads/ \
+      | while read -r r sym; do \
+          if [ \"$r\" = \"refs/heads/$base\" ] || [ \"$r\" = \"refs/heads/$keep\" ] || [ \"$r\" = \"$cur\" ]; then continue; fi; \
+          if [ -n \"$sym\" ]; then \
+            echo \"cleanup: skipping ${r#refs/heads/} (symbolic ref)\" >&2; continue; \
+          fi; \
+          echo \"$r\"; \
+        done \
+      | tr '\\n' '\\0' \
+      | CLEANUP_REF=\"$ref\" xargs -0 -P \"$jobs\" -n 20 sh -c ' \
+          for r in \"$@\"; do \
+            if ! out=$(git cherry \"$CLEANUP_REF\" \"$r\" 2>/dev/null); then \
+              echo \"S $r cannot compare\"; continue; \
+            fi; \
+            set -f; unmerged=; \
+            for t in $out; do if [ \"$t\" = + ]; then unmerged=1; break; fi; done; \
+            set +f; \
+            if [ -n \"$unmerged\" ]; then continue; fi; \
+            if [ \"$(git rev-list --count --min-parents=2 \"$CLEANUP_REF..$r\")\" != 0 ]; then \
+              echo \"S $r unique merge commits\"; continue; \
+            fi; \
+            echo \"D $r\"; \
+          done \
+        ' cleanup-worker \
+    ) || { echo 'cleanup: comparison failed; deleting nothing' >&2; return 1; }; \
+    [ -n \"$verdicts\" ] || return 0; \
+    printf '%s\\n' \"$verdicts\" | LC_ALL=C sort -k2,2 | while read -r verdict r reason; do \
+      case $r in refs/heads/?*) ;; \
+        *) echo \"cleanup: ignoring malformed verdict\" >&2; continue;; esac; \
       b=${r#refs/heads/}; \
-      if ! out=$(git cherry \"$ref\" \"$r\" 2>/dev/null); then echo \"cleanup: skipping $b (cannot compare)\" >&2; continue; fi; \
-      if printf '%s' \"$out\" | grep -q '^+'; then continue; fi; \
-      if [ \"$(git rev-list --count --min-parents=2 \"$ref..$r\")\" != 0 ]; then echo \"cleanup: skipping $b (unique merge commits)\" >&2; continue; fi; \
-      git branch -D -- \"$b\"; \
+      if [ \"$verdict\" != D ]; then echo \"cleanup: skipping $b ($reason)\" >&2; \
+      elif [ \"$r\" = \"refs/heads/$base\" ] || [ \"$r\" = \"refs/heads/$keep\" ] \
+        || [ \"$r\" = \"$cur\" ]; then \
+        echo \"cleanup: refusing to delete protected branch $b\" >&2; \
+      else git branch -D -- \"$b\"; fi; \
     done; \
   }; f"
   # Pull the current branch, then prune whatever that merged. Takes the same optional base.


### PR DESCRIPTION
## Summary

- `git pc` took ~30 seconds in a repository with a few hundred local branches. Profiling showed nearly all of it inside `cleanup` rather than the pull — the pull itself is ~1s
- The loop spends one `git cherry` per branch, and each one rebuilds a patch-id table covering every commit that branch sits behind the base. Cost scales with how stale a branch is: a branch forked ~7,000 commits ago measured 271ms against 22ms for one forked last week, and that table is rebuilt from scratch for every branch
- Each iteration also piped `git cherry` output into `grep` just to test for a leading `+`, paying a second process per branch for something the shell can do itself
- The comparisons are independent, so they now fan out across `xargs -P` sized to the machine's processors. Workers only classify and print a verdict; deletion stays serial and runs after every verdict is collected, so no ref disappears while another process is still walking the ref table
- Verdicts are sorted by ref name before anything is deleted. Workers finish out of order, and the list of deleted branches is this command's audit trail — scanning a scrambled one for a branch you did not expect to lose is materially harder
- The `grep` is replaced by scanning the output words for a bare `+`. That is exact only while `git cherry` stays unadorned — adding `-v` would put commit subjects in the stream and a subject containing a lone `+` would read as unmerged. The comments record that constraint, along with why branches travel NUL-delimited (ref names may contain quotes, which `xargs` would otherwise treat as syntax) and what the `cleanup-worker` argument guards against (without it `xargs` binds the first branch of every batch to `$0`, where the loop over `$@` never reaches it — roughly one branch in twenty would go silently uncompared)
- Measured on a 397-branch repository: **22.6s → 3.2s**

Splitting classification from deletion introduces failure modes the serial loop could not have, so four guards come with it:

- The reader re-checks the base, current, and repository base branches before deleting. Serially, "a protected branch can never reach the delete" was visible in one loop; split apart it becomes a claim about the whole pipeline
- A fan-out exiting non-zero deletes nothing, rather than acting on a partial verdict list
- The reader ignores any verdict whose ref is not under `refs/heads/`, so a torn or truncated line cannot reach `git branch -D` as a bare or half-formed name
- The worker count rejects `0` (which means *unbounded* to GNU xargs) and caps at 16, since `getconf` reports host processors rather than any cgroup quota

## One deliberate behavior change

A symbolic ref under `refs/heads/` used to be kept or deleted **purely on name order**. Its comparison only failed if its target happened to sort ahead of it and had already been deleted — so `aaa-alias` → `zzz-target` was deleted, while `zzz-alias` → `aaa-target` survived, in otherwise identical repositories. Deciding every branch against one pre-deletion snapshot makes the case reachable consistently, and symbolic refs are now skipped outright: a symref is not a branch, and which of the two names `git branch -D` would take is the kind of question this command should decline.

Everything else is unchanged. Given this alias once force-deleted every branch in a master-based repository, that was verified by differential testing rather than inspection.

## Test plan

Both implementations were extracted from the actual parsed alias (`git config --get alias.cleanup`) with `git branch -D` stubbed to an `echo`, then run side by side. Comparison is `cmp` on raw stdout and stderr plus exit code — **not** sorted, so ordering regressions cannot hide.

- [x] 397-branch repository — byte-identical
- [x] 370-branch repository where 250 branches are deleted in a single run, spanning ~19 worker batches — byte-identical, including deletion order
- [x] Branch merged by rebase (patch-equivalent, different SHA) — still deleted
- [x] Branch carrying a merge commit — still skipped with `unique merge commits`
- [x] Branch whose tip is an ancestor of the base — still deleted
- [x] Genuinely unmerged branch — still kept
- [x] Branch names containing `'` and `"` — handled identically (confirmed refs cannot contain spaces, so the space-delimited verdict format is safe)
- [x] A tag shadowing the base branch's name — the documented ambiguity hazard, identical behavior
- [x] Empty candidate set — no spurious output, exit 0
- [x] Detached HEAD — identical
- [x] Base resolving only on `origin` — identical
- [x] Base that does not resolve — same abort message, exit 1
- [x] Explicit base argument — identical
- [x] Worker count resolves correctly for empty, non-numeric, `0`, normal, and oversized `getconf` output
- [x] Fan-out returns 0 across repeated runs on the 397-branch repository, confirming the new non-zero check will not fire spuriously
- [x] Symbolic ref under `refs/heads/`, both name orderings, with **real deletions** inspecting `.git/refs/heads/` rather than `for-each-ref` (which does not list a dangling symref)
- [x] Branch held by a linked worktree — `git branch -D` refuses, and the exit code matches the serial version
- [x] Partial fan-out: `xargs` aborting mid-run, and `xargs` absent entirely — both delete nothing, report `comparison failed`, and exit 1
- [x] Verified `tr '\n' '\0'` and `xargs -0 -P` behave as required on BSD/macOS, and that git's config parser passes the escapes through without introducing literal newlines or tabs

## Review

Reviewed by four expert agents in isolated worktrees. Findings folded in:

- **Documentation** — the `cleanup-worker` comment stated the wrong rationale *and* the wrong failure mode. Corrected: it guards against silent per-batch loss of the first branch, not an empty-input edge case that never triggers
- **Security** — approved, no critical or high findings. Adversarial ref names (`x;touch$IFS/tmp/pwn;y`, backtick and `$(...)` payloads, `--force`, `-D`, 6000-byte names, a hostile clone controlling `origin/HEAD`) could not achieve injection or forge a verdict. Their protected-branch recheck and worker-count hardening are included above
- **Best practices** — caught that the original differential testing compared *sorted* output, which hid the ordering regression now fixed and covered by the 250-deletion case above
- **Test-suite architect** — found that stubbing `git branch -D` structurally cannot observe refs disappearing mid-run, which is how the symref divergence above went unnoticed; also that a partial fan-out failed silently while returning 0. Both are fixed and covered by real-deletion tests. Their remaining checks came back clean: 36 hostile-but-legal ref names, 3000 branches against `ARG_MAX`, batch boundaries at 19/20/21/40/400, octopus and orphan-root merges, hostile `IFS`, and every base-resolution path
