### PR TITLE
Isolate review subagents in throwaway git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the throwaway worktrees Claude Code creates for its subagents
+/.claude/worktrees/

--- a/home/.claude/CLAUDE.md
+++ b/home/.claude/CLAUDE.md
@@ -91,6 +91,64 @@ After completing any coding task, run these commands in order:
 - When writing slash commands, agent files, or docs that prescribe shell commands, prescribe the
   non-interactive form — a command file that says to run an editor-opening command will be followed
 
+# Git Worktrees
+
+Subagents have Edit and Write access, and several of them often run against the same checkout at
+once — every reviewer in `/local-review`, for instance. An agent that edits files to test an
+assertion corrupts what its siblings are reading, and leaves changes in the working tree that
+nobody asked for. Worktrees are how that work gets isolated.
+
+## Isolating Subagents
+
+- Spawn any subagent that reviews, tests, or otherwise exercises code with `isolation: "worktree"`.
+  The harness gives it a throwaway checkout under `.claude/worktrees/agent-<id>/`, locks it while
+  the agent runs, and removes it afterward when nothing changed. Prose constraints in a prompt are
+  advisory; a worktree is structural
+- An agent that discovers mid-task that it needs to modify code uses the `EnterWorktree` tool
+  rather than `git worktree add`, so the harness tracks and cleans up the result. `ExitWorktree`
+  with `action: "remove"` tears it down
+- Do not put `isolation: worktree` in an agent's frontmatter. These agents are also invoked
+  directly to do real work, and frontmatter isolation would silently divert that work into a
+  worktree that later gets swept
+- `worktree.baseRef` is `head` in `~/.claude/settings.json` so an isolated agent branches from the
+  current `HEAD`. The default, `fresh`, branches from `origin/<default branch>` — a reviewer would
+  analyze the wrong code and never notice
+- Uncommitted changes do **not** follow an agent into its worktree, because `head` resolves to the
+  last commit. When the work under review is uncommitted, either commit it first or capture
+  `git diff HEAD` and pass it in the delegation prompt
+
+## Bootstrapping a Worktree
+
+A worktree is a fresh checkout: no `node_modules`, no `tmp/`, and none of the gitignored
+configuration an application needs to boot. A `.worktreeinclude` file at the project root lists the
+gitignored files to copy in — `.gitignore` syntax, and only files that both match a pattern and are
+gitignored are copied. Anything else (`bundle install`, `yarn install`, `bin/rails db:test:prepare`)
+the agent runs itself, inside the worktree.
+
+If a worktree still cannot be made to run, report the finding as unverified. Never fall back to
+running in the shared checkout — that failure path is exactly how an isolated agent ends up
+modifying the real working tree.
+
+## What a Worktree Does Not Isolate
+
+A worktree has its own files and index. Everything else is shared with the real repository:
+
+- **Refs and objects** — `git branch -D`, `git stash`, `git tag`, and `git reflog expire` all write
+  to the one shared `.git` directory. The `git cleanup` / `bclean` / `bdone` aliases in
+  `~/.gitconfig` delete real branches when run from inside a worktree. Exercise destructive git
+  tooling against disposable `git init` repositories under the scratchpad, never a worktree
+- **Databases and services** — the same PostgreSQL server, Redis instance, and Elasticsearch
+  cluster. Two agents running the suite will truncate each other's test database unless each points
+  at its own; see the project's own instructions for how
+- **Ports** — only one agent can bind a given port, so only one can run a server or a system spec
+
+## Cleaning Up
+
+Leave the shared checkout exactly as you found it: `git status --porcelain` in the main working
+tree must return what it returned before you started. Remove a worktree you created manually with
+`git worktree remove <path>`, adding `--force` when it holds uncommitted files, and follow up with
+`git worktree prune`. Scratch files belong in the session scratchpad, not in the repository.
+
 # Serena MCP Server
 
 - Serena must be activated at the start of each session before its tools can be used

--- a/home/.claude/agents/code-best-practices-reviewer.md
+++ b/home/.claude/agents/code-best-practices-reviewer.md
@@ -20,7 +20,7 @@ description: |-
   The user has completed a module and implicitly wants review before finalizing, so use the code-best-practices-reviewer agent.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
 model: opus
 memory: project
 effort: high
@@ -91,3 +91,16 @@ languages and frameworks.
 If you need clarification about the code's purpose, requirements, or constraints, proactively ask
 before providing review feedback. Your goal is to help developers write better, more maintainable
 code while fostering a positive learning environment.
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/documentation-expert.md
+++ b/home/.claude/agents/documentation-expert.md
@@ -38,7 +38,7 @@ description: |-
   API documentation needs structured formatting, example payloads, error codes, and clear parameter descriptions. Use the documentation-expert agent.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
 model: sonnet
 memory: project
 skills:
@@ -267,3 +267,16 @@ Before finalizing any documentation:
 - [ ] Check for broken links or references to removed/renamed features
 - [ ] State all prerequisites and assumptions explicitly
 - [ ] Ensure the document can stand alone — readers should not need tribal knowledge
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/postgresql-expert.md
+++ b/home/.claude/agents/postgresql-expert.md
@@ -29,7 +29,7 @@ description: |-
   JSONB vs relational design decisions require PostgreSQL expertise on indexing, query performance, and data access patterns.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
 model: opus
 memory: project
 effort: high
@@ -139,3 +139,16 @@ When working with Ruby on Rails applications:
 If you need more context about the database schema, query patterns, or performance metrics,
 proactively ask before making recommendations. Your goal is to help developers build fast, reliable,
 and maintainable database systems.
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/ruby-on-rails-expert.md
+++ b/home/.claude/agents/ruby-on-rails-expert.md
@@ -29,7 +29,7 @@ description: |-
   Rails upgrades require knowledge of deprecations, breaking changes, and new features. Use the ruby-on-rails-expert agent.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*, mcp__rubocop__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*, mcp__rubocop__*
 model: opus
 memory: project
 effort: high
@@ -168,3 +168,16 @@ tools only when a project has no binstub.
 If you need more context about the application structure, gems in use, or specific requirements,
 proactively ask before making recommendations. Your goal is to help developers build maintainable,
 performant, and well-tested Rails applications.
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/security-reviewer.md
+++ b/home/.claude/agents/security-reviewer.md
@@ -29,7 +29,7 @@ description: |-
   Explicit security review requests should use the security-reviewer agent for comprehensive analysis.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
 model: opus
 memory: project
 effort: high
@@ -164,3 +164,16 @@ Best practice recommendations and defense-in-depth suggestions.
 
 Every finding should be thorough and actionable — a single critical vulnerability can compromise an
 entire application.
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/test-suite-architect.md
+++ b/home/.claude/agents/test-suite-architect.md
@@ -28,7 +28,7 @@ description: |-
     The user is asking for testing expertise and strategy, perfect for the test-suite-architect agent.
     </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*
 model: opus
 memory: project
 effort: high
@@ -133,3 +133,16 @@ If you encounter ambiguity about testing requirements, proactively ask for clari
 - Performance requirements
 - Integration points that need testing
 - Specific testing frameworks or tools to use
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/agents/ui-ux-design-specialist.md
+++ b/home/.claude/agents/ui-ux-design-specialist.md
@@ -40,7 +40,7 @@ description: |-
   After UI styling work is completed, proactively engage the ui-ux-design-specialist agent to review navigation patterns, keyboard accessibility, and visual design quality.
   </commentary>
   </example>
-tools: Glob, Grep, Read, Edit, Write, Bash, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*, mcp__chrome-devtools__*
+tools: Glob, Grep, Read, Edit, Write, Bash, EnterWorktree, ExitWorktree, WebFetch, WebSearch, Skill, ToolSearch, mcp__serena__*, mcp__chrome-devtools__*
 model: opus
 memory: project
 effort: high
@@ -174,3 +174,16 @@ Before finalizing any recommendation, verify:
 - [ ] Reasoning is explained with design principles
 - [ ] Code examples follow the project's actual conventions (its stylesheet language, template
       language, and lint rules)
+
+## Working Alongside Other Agents
+
+You can edit and write files, and you are frequently one of several agents working from the same
+checkout at the same time — every reviewer in a `/local-review` run, for example.
+
+- **When you are reviewing, advise — do not fix.** Your deliverable is findings the human decides
+  on. Silently applying a fix removes it from the review record and grows a diff nobody approved
+- **When you must change or run code to verify a claim, do it in an isolated worktree.** If you
+  were spawned with `isolation: "worktree"` you are already in one; otherwise call `EnterWorktree`.
+  See Git Worktrees in `~/.claude/CLAUDE.md` for what a worktree does and does not isolate
+- **Leave the shared checkout exactly as you found it.** If you cannot get an isolated checkout
+  running, report the finding as unverified rather than editing the shared one

--- a/home/.claude/commands/doc-review.md
+++ b/home/.claude/commands/doc-review.md
@@ -78,6 +78,22 @@ Instruct the documentation-expert to perform a thorough review covering:
 - **Deprecated references** — Flag mentions of tools, APIs, libraries, or
   practices that are known to be deprecated or superseded
 
+## Reviewing Without Editing
+
+The documentation-expert can write files, and the only file it should write is the review. Report
+every problem as a finding; do not correct the document in place. A silent fix removes the finding
+from the review record and grows a diff nobody approved, and it defeats the point of a review the
+human acts on.
+
+Checking an **Accuracy** claim often means running something — a documented command, a code sample,
+a configuration snippet. Anything that would modify the repository to do so belongs in an isolated
+worktree: call `EnterWorktree`, verify there, then `ExitWorktree` with `action: "remove"`. Read-only
+checks need no worktree. If a claim cannot be checked without changing the shared checkout, report
+it as unverified and say what would settle it. See Git Worktrees in `~/.claude/CLAUDE.md`.
+
+When the review spawns parallel subagents to read disjoint page ranges, those subagents read only —
+page ranges do not need worktrees.
+
 ## Output
 
 ### Review File

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -50,9 +50,22 @@ alias yo="yarn upgrade-interactive"
 
 # Git worktrees - navigate by number (e.g., wt 1, wt 2)
 # Run from any worktree to switch between them
+#
+# `git worktree list` sorts linked worktrees by directory name, which would interleave the
+# throwaway worktrees Claude Code creates for its subagents (`.claude/worktrees/agent-<id>`) with
+# the permanent ones and renumber them mid-session. Listing the temporary ones last keeps `wt 2`
+# pointing at the same checkout whether or not agents are running.
+wtlist() {
+  git worktree list 2>/dev/null | awk '
+    index($1, "/.claude/worktrees/") { temporary[++count] = $0; next }
+    { print }
+    END { for (i = 1; i <= count; i++) print temporary[i] }
+  '
+}
+
 wt() {
   local worktree_path
-  worktree_path=$(git worktree list 2>/dev/null | sed -n "${1}p" | awk '{print $1}')
+  worktree_path=$(wtlist | sed -n "${1}p" | awk '{print $1}')
   if [[ -n "$worktree_path" ]]; then
     cd "$worktree_path" || return
   else
@@ -61,7 +74,7 @@ wt() {
 }
 
 # List all worktrees with numbers
-alias wtl='git worktree list | nl'
+alias wtl='wtlist | nl'
 
 # Docker
 alias dc='docker compose'

--- a/worktree-isolation-guidance-DOC-REVIEW.md
+++ b/worktree-isolation-guidance-DOC-REVIEW.md
@@ -1,0 +1,198 @@
+# Document Review: worktree isolation guidance (four repos)
+
+| | |
+|---|---|
+| **Scope** | dotfiles `isolate-review-agents-in-worktrees` @ `7ef4981`; alice `isolate-review-agents-in-worktrees` @ `30170c4cf`; KleinsShopRite `local-review-command` @ `9387541`; ORE `isolate-review-agents-in-worktrees` @ `4f60233` |
+| **Reviewed** | 2026-08-04 |
+| **Reviewers** | 4 × documentation-expert, Opus 5 (`claude-opus-5[1m]`), each in an isolated worktree |
+| **Findings** | 72 total — 6 Critical, 12 High, 16 Medium, 13 Low, 25 observations |
+
+## Review History
+
+### 2026-08-04 — Initial review
+
+Four documentation-expert agents reviewed one repo each. Findings prefixed D (dotfiles),
+A (alice), K (KleinsShopRite), O (ORE). The orchestrator independently re-verified every
+Critical finding against primary sources before recording it.
+
+## Orchestrator Verification
+
+Six claims were re-checked directly rather than taken on the reviewers' word. All six held.
+
+| Claim | Source of truth | Verdict |
+|---|---|---|
+| `worktree.baseRef: head` is not in effect (A3, K2, O2) | `~/.claude/settings.json` is a **regular file** dated Jul 29 with no `worktree` key; `~/.claude/{CLAUDE.md,agents,commands}` are symlinks to the repo but `settings.json` is not | ✅ Confirmed |
+| Reviewer worktrees were cut from `origin/main` | A reviewer's worktree was at `ea4cbda` = `origin/main`, while branch HEAD was `7ef4981` | ✅ Confirmed empirically |
+| `bin/rails db:drop` drops the development database (A1, K1) | `activerecord-8.1.3.1` `databases.rake:63` — "Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases" | ✅ Confirmed |
+| KSR's own linter rejects the new section (K9) | `bin/lint-markdown .claude/commands/local-review.md` → **21 MD013 errors**, exit 2; `.markdown-lint.yml` is `default: true`, so MD013 = 80 | ✅ Confirmed |
+| A worktree checks out an empty submodule (O1) | Sandbox `git init` superproject + submodule: main checkout `ore/` populated, linked worktree `ore/` **empty** | ✅ Confirmed |
+| Shell state does not persist between an agent's Bash calls (A2, K3) | Harness contract: "Working directory persists between calls… Shell state (env vars, functions) does not persist" | ✅ Confirmed |
+
+### Correction to an earlier claim
+
+Both PR test plans state "markdownlint clean on every changed file." **That verification was
+invalid.** It ran alice's `bin/lint-markdown` against files in other repos; that script computes
+the path relative to alice's root and `exit 0`s when it does not match
+`^\.claude/(commands|agents)/.+\.md$`. Every out-of-repo file was silently skipped, not linted.
+
+Re-checked with each repo's own configuration:
+
+- **alice** — genuinely linted and clean (no repo config; `bin/mdl` with no `.mdlrc`)
+- **ORE** — `.markdownlint.yml` sets `MD013: line_length: 100`; all added lines ≤ 99 ✅
+- **KleinsShopRite** — `.markdown-lint.yml` is `default: true` → MD013 = 80 → **21 errors** ❌
+- **dotfiles** — no linter; the 100-character preference applies and is met
+
+`D14` (four lines at 101 characters) is a **false positive**: the reviewer counted bytes, and em
+dashes are 3 bytes each. No line exceeds 100 *characters*; the longest is exactly 100.
+
+## Critical Findings
+
+### F-C1 🔴 The `worktree.baseRef` setting was never deployed — every claim resting on it is false
+
+**Found independently by three reviewers (A3, K2, O2).** `~/.claude/settings.json` is a real file,
+not a symlink into the dotfiles castle, so editing `home/.claude/settings.json` changed nothing.
+Reviewer worktrees are therefore cut from the default branch and contain **none of the change set**
+— not merely the uncommitted part the docs warn about. A reviewer would confidently review code
+that does not include the change under review, and nothing in its output would reveal it.
+
+The live and repo copies have also drifted in both directions, so symlinking is not a no-op:
+
+```text
+repo only:   "worktree": {"baseRef": "head"}
+repo=true / live=false:   enabledPlugins["learning-output-style@claude-code-plugins"]
+live only:   "skillOverrides": {"rails-audit-thoughtbot": "off"}
+```
+
+**Recommendation: Implement** — the feature does not work at all until this is resolved, and the
+documentation asserts it does.
+
+### F-C2 🔴 `bin/rails db:drop` destroys the shared development database (A1, K1)
+
+Prescribed as the cleanup step in both alice and KleinsShopRite. With `RAILS_ENV` unset it drops
+development *and* test. Since one PostgreSQL server serves every worktree — the section's own
+premise — this destroys `alice_development` for all nine checkouts. Fix: `RAILS_ENV=test bin/rails
+db:drop`, or `dropdb "$TEST_DATABASE"`.
+
+**Recommendation: Implement** — a documented command that causes data loss.
+
+### F-C3 🔴 The `export`ed variables never reach the command that runs the specs (A2, K3)
+
+Shell state does not survive between an agent's Bash calls. The snippet exports `TEST_DATABASE`
+and `CHEWY_PREFIX`, then the reviewer runs `bin/rspec` in a *later* call where both are gone — so
+every reviewer converges on the shared `alice_test` and truncates the others mid-run. Silently.
+This is the exact failure the section exists to prevent. Fix: write them to `.env.test.local`
+inside the worktree (dotenv loads it first in the test environment, and it is gitignored), or
+prefix every command individually.
+
+**Recommendation: Implement** — the recipe cannot work as written.
+
+### F-C4 🔴 ORE reviewer worktrees have an empty `ore/` submodule (O1)
+
+`git worktree add` does not populate submodules, and `git submodule update --init` re-clones rather
+than reusing the superproject's objects. Four of five ORE agents are pointed at paths under `ore/`,
+and a submodule-bump branch — routine here — would present as an empty change set. Verified in a
+sandbox.
+
+**Recommendation: Implement** — the isolation change silently reduces ORE review coverage to the
+non-submodule tree.
+
+### F-C5 🔴 The Chewy prefix nests under the default, so a normal spec run deletes it (A4)
+
+`CHEWY_PREFIX="test_${SUFFIX}"` yields `alice_test_<suffix>_*`. `Chewy.massacre` — run before every
+`:elasticsearch` example via `spec/support/reset.rb` — deletes `alice_test_*`, which matches. The
+namespacing is one-way and "Nothing else can hold those names" is false. Fix: a sibling namespace,
+`CHEWY_PREFIX="agent_${SUFFIX}"`.
+
+**Recommendation: Implement** — a one-word change closes a collision the section promises to close.
+
+### F-C6 🔴 KleinsShopRite's new section breaks the repo's own lint gate (K9)
+
+21 MD013 errors at 80 characters, in a file that passed clean before the commit. `bin/lint-markdown`
+exits 2 and is wired to a `PostToolUse` hook for `**/*.md`, so the file now blocks its own future
+edits. The global 100-character preference explicitly defers to a project's own linter.
+
+**Recommendation: Implement** — mechanical, and it currently breaks tooling.
+
+## High-Priority Findings
+
+| # | Repo | Finding | Recommendation |
+|---|---|---|---|
+| D6 / A13 | dotfiles, alice | "the only file it should write is the review" contradicts the same file's Interactive Finding Selection step and the PR-comment step | Implement |
+| D7 | dotfiles | `doc-review.md` prescribes `EnterWorktree` unconditionally; it errors when the agent is already isolated. The agent files get this right — `doc-review.md` diverges from its own agent | Implement |
+| D10 | dotfiles | An isolated agent's Bash is confined to its worktree — `git -C <main checkout>` is refused outright, as are compound commands. Unstated, and every spawned agent hits it | Implement |
+| K7 / O8 | KSR, ORE | "Return the checkout clean" contradicts the run's own output file, and the collating documentation-expert is not excluded from isolation — isolating it writes `local-review.md` into a worktree that is then swept, losing the review with no error | Implement |
+| A5 | alice | `.worktreeinclude`'s comment argues against copying `.env.development.local`, then copies it | Implement |
+| A6 | alice | The resource-claiming recipe is written to the reviewer but sits outside the "relay these constraints" list, so it never reaches them | Implement |
+| A7 | alice | A fresh worktree has no built assets (`app/assets/builds/*` gitignored); any spec rendering the layout fails | Implement |
+| O2 | ORE | Same as F-C1, stated locally: the `baseRef` dependency is unstated and machine-specific | Implement |
+| O3 | ORE | The no-build / no-`ctest` rule sits outside the relayed bullets and switches person, so an orchestrator relays three bullets and drops it | Implement |
+| O4 | ORE | `git diff HEAD` renders submodule changes as a gitlink only — uncommitted `ore/` work is invisible. Use `--submodule=diff` | Implement |
+| K3 | KSR | Same as F-C3 | Implement |
+
+## Medium and Low Findings
+
+Recorded in full from each reviewer; abbreviated here.
+
+**dotfiles** — D1 "gets swept" overstates (the sweep skips worktrees holding work); D2 permission
+approvals write to the main checkout and are missing from the shared-state list; D3 `git worktree
+prune` is a no-op after `remove`; D8 "advise — do not fix" needs an "unless asked" carve-out;
+D9 five different names for the main checkout; D11 "page ranges" assumes PDFs; D17 the `wtlist`
+comment describes a narrower filter than the code (`.claude/worktrees/` also matches named
+`--worktree` sessions). D12, D15 recommended **Skip**.
+
+**alice** — A8 index cleanup has no command; A9 the port probe has no stated use case and Capybara
+self-assigns; A10 the `3000 + position` formula is wrong for the main checkout; A11 the suffix is
+not lowercased and Elasticsearch rejects uppercase index names; A14 the agents directory is now
+half-converted to real headings (**Defer**). A12, A15 recommended **Skip**.
+
+**KleinsShopRite** — K4 the database name is 57/63 bytes — no truncation today, but `${PWD##*/}`
+breaks if the reviewer has `cd`'d into a subdirectory; K5 the port probe computes a value nothing
+uses; K6 `git diff HEAD` omits untracked files; K8 system specs need `yarn install` in the
+worktree; K10–K12 punctuation and phrasing.
+
+**ORE** — O6 "changing code to verify is expected" is withdrawn two paragraphs later by the build
+ban; O7 "unverified" has no slot in the finding format; O9 `.markdownlintignore` was not updated
+alongside `.gitignore`; O10 "clean" should be "unchanged". O11 **Defer**; O12, O13 **Skip**.
+
+## Observations Worth Acting On
+
+- **A21 / K13** — `config/credentials/*.key` copies production (and staging) keys into every
+  throwaway worktree. Only `config/master.key` is needed to boot. Narrowing the pattern costs
+  nothing.
+- **A21 footnote, out of scope** — `.yarnrc.yml` is tracked in alice and contains a live Font
+  Awesome Pro `npmAuthToken`. Pre-existing and possibly intentional for a private registry, but
+  flagged since a secrets sweep was in the brief.
+- **O5** — the `memory: project` → Edit/Write claim is correct, with the caveat that it has no
+  effect when auto memory is disabled.
+- **D16 / A19 / O15–O17** — the mechanical rollout is clean: the conduct section is byte-identical
+  across all 15 editing agents, correctly placed, and every agent that is told to call
+  `EnterWorktree` actually has it.
+
+## Overall Assessment
+
+The prose is strong — mechanism-first, well-voiced, and every cross-reference resolves. The problem
+is underneath it: the executable core was never run end to end. Four independent defects (F-C1
+through F-C3, plus F-C5) each cause precisely the damage the guidance promises to prevent, and each
+fails silently. The agent-file changes, the heading conversion, and the `.gitignore` work are sound
+and need not hold up the branches.
+
+The single most important item is F-C1. Until `~/.claude/settings.json` actually carries
+`worktree.baseRef: head`, worktree-isolated reviewers review the wrong tree — which also means the
+four reviews above were only valid because each agent was handed absolute paths into the main
+checkout rather than relying on its worktree.
+
+## Checklist
+
+- [ ] F-C1 — Deploy `worktree.baseRef: head` and reconcile the drifted settings file
+- [ ] F-C2 — `RAILS_ENV=test bin/rails db:drop` in alice and KSR
+- [ ] F-C3 — Stop relying on `export`; persist via `.env.test.local` or per-command prefixes
+- [ ] F-C4 — Document the empty `ore/` submodule and how reviewers should read it
+- [ ] F-C5 — Switch alice's Chewy prefix to a sibling namespace
+- [ ] F-C6 — Rewrap KSR's section at 80 characters until `bin/lint-markdown` exits 0
+- [ ] D6 / A13 — Scope "do not edit" to the review phase
+- [ ] D7 — Make the `EnterWorktree` instruction conditional
+- [ ] D10 — Document that an isolated agent's shell cannot reach the main checkout
+- [ ] K7 / O8 — Exempt the review output file; state the collator is not isolated
+- [ ] A5, A6, A7 — Settle the `.worktreeinclude` contradiction; relay the recipe; add built assets
+- [ ] O2, O3, O4 — State the `baseRef` dependency; relay the no-build rule; `--submodule=diff`
+- [ ] Medium/Low sweep — D1, D2, D3, D8, D9, D11, D17, A8–A11, K4–K6, K8, K10–K12, O6, O7, O9, O10


### PR DESCRIPTION
## Summary

Every user-level subagent carries Edit and Write access, and a `/local-review` run puts several of them to work against one checkout at the same time. A reviewer that edits a file to test an assertion changes what its siblings are reading, and leaves changes in the working tree that nobody asked for. This adds the discipline that makes those grants safe, and fixes two harness defaults that would have quietly undermined it.

- **`home/.claude/CLAUDE.md`** gains a `# Git Worktrees` section holding the procedure once: how to isolate an agent, how to bootstrap a fresh checkout, what a worktree still shares with the real repository, and how to clean up. Custom subagents load the whole CLAUDE.md hierarchy (only the built-in `Explore` and `Plan` skip it), so one copy reaches every agent in every project
- **All seven agents** gain a short `## Working Alongside Other Agents` section — advise rather than fix, verify only inside an isolated checkout, return the shared tree untouched
- **All seven agents** also gain `EnterWorktree` and `ExitWorktree`. Without these the instruction above would be unusable: an explicit `tools:` list is a whitelist, not an addition to the default pool, so the tool was not actually reachable
- **`worktree.baseRef` is set to `head`.** The default, `fresh`, branches an isolated agent from `origin/<default branch>` rather than the work under review — reviewers would have analyzed `main` while reporting on a feature branch, with nothing in their output to reveal it
- **`wt` / `wtl` are hardened.** `git worktree list` sorts linked worktrees by directory basename, so the harness's `.claude/worktrees/agent-<id>` checkouts sorted *ahead* of `alice2`–`alice8` and renumbered them mid-session. Both now read through a `wtlist` helper that lists those entries last
- **`/doc-review`** gains a `## Reviewing Without Editing` section: the only file the documentation-expert should write is the review, and accuracy checks that would modify the repository belong in a worktree
- **`.gitignore`** now covers `/.claude/worktrees/`, which was showing up as untracked

## Test plan

- [x] `git worktree list` ordering confirmed empirically in a throwaway repo: git sorts linked worktrees by basename, so `agent-<id>` landed at position 2 ahead of `main2`/`main8`
- [x] With the `wtlist` helper, the same repo lists the agent worktree last, and `wt 2` resolves to the second permanent worktree rather than the agent's
- [x] `zsh -n ~/.zshrc` parses; `wtl` and `wt 2` exercised end to end in a real `zsh`
- [x] `settings.json` is valid JSON
- [x] All 7 agent files parse as YAML frontmatter, with `EnterWorktree` and `ExitWorktree` present in every `tools:` list
- [x] markdownlint clean on every changed Markdown file
- [x] No new line exceeds 100 characters
- [ ] Not yet exercised: a full `/local-review` run with reviewers actually spawned under `isolation: "worktree"`

Requires `source ~/.zshrc` to pick up `wtlist`.
