### PR TITLE
Add a sysdoc function that runs every health check

### DIFF
--- a/home/.zsh/functions/sysdoc
+++ b/home/.zsh/functions/sysdoc
@@ -1,0 +1,36 @@
+# Report on the health of this machine's tooling. Every check runs regardless of how the last
+# fared, since a doctor exiting non-zero is routine — `brew doctor` calls its own warnings
+# ignorable.
+#
+# Autoloaded: the bare body with no `sysdoc() { ... }` wrapper is zsh's fpath convention.
+
+# Without this, a caller under KSH_ARRAYS runs only the first check and still returns 0.
+emulate -L zsh
+
+local -a checks=(
+  'brew doctor'
+  'claude doctor'
+  'npm doctor'
+  'mise doctor'
+  'gh auth status' # pr-conflicts depends on gh, and an expired token fails silently
+)
+local check tool
+local -i failed=0
+
+for check in $checks; do
+  tool=${check%% *}
+
+  # `commands` holds external binaries only, never shell functions — mise is both here, and it is
+  # the binary this finds.
+  if (( ! $+commands[$tool] )); then
+    echo "==> skipping $check ($tool not installed)"
+    continue
+  fi
+
+  echo "==> $check"
+  # zsh, unlike bash, does not word-split unquoted parameters; without the `=` this would look for
+  # a command named `gh auth status`.
+  ${=check} || failed=1
+done
+
+return $failed

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -14,6 +14,14 @@ ZSH=$HOME/.oh-my-zsh
 # time that oh-my-zsh is loaded.
 ZSH_THEME="robbyrussell"
 
+# Autoload functions from ~/.zsh/functions, ahead of the compinit that oh-my-zsh runs. Each is
+# named rather than globbed out of the directory: autoload takes the name from an absolute path's
+# basename, and zsh resolves functions before external commands, so a glob would make any file
+# landing in there a live command — one named `git` would shadow the real binary.
+typeset -U fpath
+fpath=(~/.zsh/functions $fpath)
+autoload -Uz ~/.zsh/functions/sysdoc
+
 alias e='exec'
 alias ta='tmux -2 attach || tn'
 alias be="bundle exec"
@@ -91,7 +99,6 @@ alias bubo="brew update && brew outdated"
 alias brewup="HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS=1 brew upgrade && brew cleanup && brew autoremove && brew doctor"
 # Consider using `brew cleanup --prune=all --dry-run`
 # See https://mac.install.guide/homebrew/8
-
 
 # Set to this to use case-sensitive completion
 # CASE_SENSITIVE="true"


### PR DESCRIPTION
## Summary

- Adds a `sysdoc` command that runs five health checks in one go — `brew doctor`, `claude doctor`, `npm doctor`, `mise doctor`, and `gh auth status` — reporting on all of them rather than stopping at the first one that complains.
- A doctor exiting non-zero is routine, not exceptional. `brew doctor` documents that it exits non-zero on any potential problem, then says in the same breath that those warnings are usually safe to ignore, and `npm doctor` exits 1 over nits like a Node point release. Running these conditionally would hide most of the report behind the first grumble.
- Each check is labeled with a `==>` header so the outputs stay readable — `npm doctor` alone prints ~30 lines. Tools that aren't installed are reported as skipped rather than aborting the run. The return value is non-zero if any check failed.
- `gh auth status` is included because this repo's own `pr-conflicts` function depends on `gh` and an expired token fails silently. `rbenv` is deliberately excluded: it has no `doctor` subcommand, only a `curl | bash` script from rbenv-installer, which would make a local health check network-dependent.
- Keeps the full `npm doctor` rather than scoping it to the fast subset. The ~18s it costs is spent almost entirely on cache verification and permissions walks, which are the checks that catch things you'd never spot by eye; the fast subset only re-checks things you'd notice anyway.

## Function loading

The body lives in `~/.zsh/functions/sysdoc` and is autoloaded, so zsh parses it on first call instead of at every shell startup, and it can be exercised without sourcing an rc file that also pulls in oh-my-zsh, syntax highlighting, and autosuggestions. The file holds the bare body with no `sysdoc() { ... }` wrapper, which is zsh's convention for an fpath functions directory.

`.zshrc` names each function to autoload rather than globbing the directory. `autoload` takes a function's name from the basename of an absolute path, and zsh resolves functions **ahead of** external commands — so a glob would turn any file landing in that directory into a live command. A file named `git` would shadow the real binary at its next invocation:

```
glob autoload:      whence -w git -> git: function   →  SHADOWED git, args=--version
explicit autoload:  whence -w git -> git: command    →  git version 2.55.0
```

That's a poor property for a directory a stray editor write or an errant agent can add to, so each function is named at the cost of one line. Naming a function whose file doesn't exist is harmless — resolution is deferred to the call, verified exit 0 at startup. `fpath` is deduplicated so re-sourcing `.zshrc` doesn't grow it, and loading runs before oh-my-zsh calls `compinit`.

## Note on linting

Moving the function to its own file was considered partly to make it lintable. That turns out not to hold: ShellCheck refuses zsh outright (`Unknown shell: zsh`), and forced into its bash dialect it raises two findings against `$+commands[...]`, both wrong — one because `commands` is a zsh special array it doesn't know about, and one (SC2004) whose advice **silently** breaks the existence test rather than announcing itself. It points at the subscript, and dropping that `$` parses cleanly while looking up a literal key named `tool`:

```
$ zsh -n t.zsh          # parses fine — no error to notice
with    $tool: 1
without $tool: 0        # every check would report its tool missing
```

`zsh -n` is the check that actually works, and it reads `.zshrc` whole just as happily. The split is still worth it for startup cost and testability — just not for linting.

## Follow-up (deliberately not in this PR)

The four functions still inline in `.zshrc` can move to `~/.zsh/functions/` the same way, each adding one `autoload` line.

## Review fixes applied

Reviewed by three subagents (code quality, security, documentation); findings verified independently before acting:

- `emulate -L zsh` added — under `KSH_ARRAYS` the function previously ran 1 of 5 checks and **returned 0**; under `SH_WORD_SPLIT` it ran `brew` instead of `brew doctor`. Both now run all five.
- Replaced the directory glob with explicit `autoload` by name, closing a command-shadowing vector: under the glob, any filename in that directory became a live function that outranks the real binary.
- `typeset -U fpath` — re-sourcing `.zshrc` no longer duplicates the entry.
- Corrected a false comment claiming none of these tools are shell functions. `mise` **is** one (oh-my-zsh's plugin); the guard works only because the binary is also on `PATH`, and the comment now says so.
- Added in-code rationale for why `gh auth status` breaks the `X doctor` pattern.

One reported finding was rejected after verification: that `homesick symlink` isn't a real subcommand. It is — `map symlink: :link` in homesick's source, an explicit compatibility alias.

## Test plan

- [x] `zsh -n home/.zshrc` and `zsh -n home/.zsh/functions/sysdoc` both parse cleanly
- [x] Generic loader autoloads `sysdoc` without naming it, and the function persists across repeated calls
- [x] Missing `~/.zsh` produces no output, no error, and no function dump at startup
- [x] Real end-to-end run: all five checks execute, aggregate exit is 1 when `npm doctor` reports problems
- [x] With stubs (a `brew` that warns, an absent `npm`, a failing `gh auth status`): every later check still runs, the missing tool is reported as skipped, exit is 1
- [x] `${=check}` word-splitting verified — without it zsh looks for a command literally named `gh auth status`
- [x] Hostile shell options: all five checks run under `KSH_ARRAYS` and `SH_WORD_SPLIT` (both previously broke)
- [x] `(N-.)` verified against both the current layout and a per-file-symlink layout
- [x] `homesick symlink dotfiles` run — `~/.zsh` is a single whole-directory symlink, and `sysdoc` resolves and runs correctly in a real shell sourcing `.zshrc`
