### PR TITLE
Branch isolated agent worktrees from HEAD

### DIFF
--- a/home/.claude/settings.json
+++ b/home/.claude/settings.json
@@ -179,6 +179,9 @@
       }
     ]
   },
+  "worktree": {
+    "baseRef": "head"
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
@@ -190,7 +193,6 @@
     "frontend-design@claude-plugins-official": true,
     "playwright-cli@playwright-cli": true,
     "ruby-lsp@claude-plugins-official": true,
-    "learning-output-style@claude-code-plugins": true,
     "feature-dev@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true
   },


### PR DESCRIPTION
## Summary

- Sets `worktree.baseRef` to `head` in `~/.claude/settings.json`. CLAUDE.md already documents this as being set — it never was, so the default `fresh` applied and isolated subagents branched from `origin/main` instead of the current `HEAD`.
- Removes the `learning-output-style@claude-code-plugins` entry, which went away when the plugin was uninstalled with `claude plugin uninstall`.

## Why the worktree setting matters

CLAUDE.md's own warning describes the failure exactly: *"The default, `fresh`, branches from `origin/<default branch>` — a reviewer would analyze the wrong code and never notice."*

That happened. Three review subagents spawned against a feature branch all landed in worktrees at `main`:

```
/…/dotfiles                          f2bdcf4 [feature branch]
/…/.claude/worktrees/agent-a1b7a2…   ea4cbda [main]
/…/.claude/worktrees/agent-aa6310…   ea4cbda [main]
```

Two noticed `git diff main...HEAD` came back empty and read the branch through the shared object store instead. The third nearly reported on code that didn't contain the change under review. Setting the key makes the documented behavior the actual one.

## On the plugin entry

It was recorded as `false`, which is how an installed-but-*disabled* plugin is stored. Deleting that line by itself would have re-enabled it — the opposite of the intent. It was removed properly via `claude plugin uninstall`, which cleaned the entry, the `installed_plugins.json` record, and its cache.

## Test plan

- [x] `settings.json` parses as valid JSON (18 keys) after the change
- [x] Diffed against a pre-change backup — only the intended keys differ, nothing else added, removed, or altered
- [x] `claude plugin list` reports the remaining 8 plugins, all enabled
- [x] Secret scan clean — `env` holds only `ENABLE_CLAUDEAI_MCP_SERVERS` and `ENABLE_TOOL_SEARCH`; no credential-shaped values anywhere in the file
- [ ] Spawn an isolated subagent and confirm its worktree now branches from `HEAD` rather than `main`

## Note

`~/.claude/settings.json` was a regular file that had drifted from the repo copy; it's now a symlink into the castle, so the two stay in sync rather than needing a manual copy.
