### PR TITLE
Keep Allow Title Setting through iTerm2's rewrite

### DIFF
--- a/home/Library/Application Support/iTerm2/DynamicProfiles/main.json
+++ b/home/Library/Application Support/iTerm2/DynamicProfiles/main.json
@@ -1,12 +1,14 @@
 {
-  "Profiles": [
+  "Profiles" : [
     {
-      "Name": "Matt (dotfiles)",
-      "Guid": "15372224-9BD7-4C77-A9E3-5B19E73AE5F0",
-      "Dynamic Profile Parent Name": "Default",
-      "Title Components": 32,
-      "Custom Window Title": "\\(session.autoName) · \\(user.dir)",
-      "Allow Title Setting": true
+      "Title Components" : 32,
+      "Rewritable" : true,
+      "Custom Window Title" : "\\(session.autoName) · \\(user.dir)",
+      "Guid" : "15372224-9BD7-4C77-A9E3-5B19E73AE5F0",
+      "Name" : "Matt (dotfiles)",
+      "Dynamic Profile Parent Name" : "Default",
+      "Use Separate Colors for Light and Dark Mode" : false,
+      "Allow Title Setting" : true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- iTerm2 rewrote this dynamic profile itself — reordering keys, imposing its own `" : "` separator, adding `Rewritable` and `Use Separate Colors for Light and Dark Mode`, and dropping the trailing newline.
- It also dropped **`Allow Title Setting`**, which is not cosmetic. This restores it, along with the trailing newline, while accepting iTerm2's formatting (it will reimpose that on its next write regardless).

## Why the dropped key matters

`.zshrc` sets `DISABLE_AUTO_TITLE="true"` to take the tab title away from oh-my-zsh, then drives it directly:

```zsh
_tab_title_running() { printf '\e]1;▶ %s\a' "$1" }
```

`Allow Title Setting` is the profile switch that permits exactly those OSC escape sequences. With the key absent the value falls through to the `Default` parent profile, so the title hooks would keep working only for as long as that parent happens to allow it — a silent dependency on something outside this file.

## Test plan

- [x] File parses as valid JSON; profile has all 8 keys
- [x] `Allow Title Setting` present and `true`
- [x] Trailing newline restored (repo convention)
- [x] Confirmed the live `~/Library/Application Support/iTerm2/DynamicProfiles/main.json` is the homesick symlink to this file, so the change is already in effect
- [x] Open a new iTerm2 tab and confirm the title still tracks `_tab_title_idle` / `_tab_title_running`

## Note

Because iTerm2 owns and rewrites this file, expect it to churn again — the key order and spacing are its serialization, not ours. Worth deciding separately whether it's worth tracking at all.
