### PR TITLE
Keep wt numbering stable when agent worktrees exist

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -50,9 +50,22 @@ alias yo="yarn upgrade-interactive"
 
 # Git worktrees - navigate by number (e.g., wt 1, wt 2)
 # Run from any worktree to switch between them
+#
+# `git worktree list` sorts linked worktrees by directory name, which would interleave the throwaway
+# worktrees Claude Code creates for its subagents (`.claude/worktrees/agent-<id>`) with the
+# permanent ones and renumber them mid-session. Listing the temporary ones last keeps `wt 2`
+# pointing at the same checkout whether or not agents are running.
+wtlist() {
+  git worktree list 2>/dev/null | awk '
+    index($1, "/.claude/worktrees/") { temporary[++count] = $0; next }
+    { print }
+    END { for (i = 1; i <= count; i++) print temporary[i] }
+  '
+}
+
 wt() {
   local worktree_path
-  worktree_path=$(git worktree list 2>/dev/null | sed -n "${1}p" | awk '{print $1}')
+  worktree_path=$(wtlist | sed -n "${1}p" | awk '{print $1}')
   if [[ -n "$worktree_path" ]]; then
     cd "$worktree_path" || return
   else
@@ -61,7 +74,7 @@ wt() {
 }
 
 # List all worktrees with numbers
-alias wtl='git worktree list | nl'
+alias wtl='wtlist | nl'
 
 # Docker
 alias dc='docker compose'

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -51,25 +51,57 @@ alias yo="yarn upgrade-interactive"
 # Git worktrees - navigate by number (e.g., wt 1, wt 2)
 # Run from any worktree to switch between them
 #
-# `git worktree list` sorts linked worktrees by directory name, which would interleave the throwaway
-# worktrees Claude Code creates for its subagents (`.claude/worktrees/agent-<id>`) with the
-# permanent ones and renumber them mid-session. Listing the temporary ones last keeps `wt 2`
+# `git worktree list` sorts linked worktrees by directory basename, which would interleave the
+# throwaway worktrees Claude Code creates for its subagents (`.claude/worktrees/agent-<id>`) with
+# the permanent ones and renumber them mid-session. Listing the temporary ones last keeps `wt 2`
 # pointing at the same checkout whether or not agents are running.
+#
+# `wtl` reorders git's own listing so it keeps the commit and branch columns, while `wt` reads
+# `--porcelain -z`, the only format that leaves a path containing spaces or newlines intact. Both
+# walk git's ordering and hold back the same entries, so the numbers you see and the directories
+# you land in stay in step.
 wtlist() {
-  git worktree list 2>/dev/null | awk '
-    index($1, "/.claude/worktrees/") { temporary[++count] = $0; next }
+  git worktree list | awk '
+    index($0, "/.claude/worktrees/") { temporary[++count] = $0; next }
     { print }
     END { for (i = 1; i <= count; i++) print temporary[i] }
   '
 }
 
+# Worktree paths in the same order `wtl` prints them, returned in $reply so that no delimiter has
+# to survive the trip back
+_wt_paths() {
+  local -a temporary
+  # `dir`, never `path`: zsh ties `path` to `PATH`, so a local of that name empties it and `git`
+  # stops resolving for the rest of the function
+  local record dir
+  reply=()
+  for record in ${(0)"$(git worktree list --porcelain -z 2>/dev/null)"}; do
+    [[ $record == 'worktree '* ]] || continue
+    dir=${record#worktree }
+    if [[ $dir == */.claude/worktrees/* ]]; then
+      temporary+=("$dir")
+    else
+      reply+=("$dir")
+    fi
+  done
+  reply+=("${temporary[@]}")
+}
+
 wt() {
+  if [[ $1 != <-> ]]; then
+    echo "Usage: wt <number>" >&2
+    return 1
+  fi
+  local -a reply
   local worktree_path
-  worktree_path=$(wtlist | sed -n "${1}p" | awk '{print $1}')
+  _wt_paths
+  worktree_path=${reply[$1]}
   if [[ -n "$worktree_path" ]]; then
     cd "$worktree_path" || return
   else
-    echo "Worktree $1 not found (are you in a git repo with worktrees?)"
+    echo "Worktree $1 not found (are you in a git repo with worktrees?)" >&2
+    return 1
   fi
 }
 


### PR DESCRIPTION
## Summary

- `git worktree list` sorts linked worktrees by directory basename, so the throwaway checkouts Claude Code creates for its subagents under `.claude/worktrees/agent-<id>` sorted in among the permanent worktrees rather than after them. A running agent renumbered the list mid-session, and `wt 2` stopped resolving to the same checkout it meant a moment earlier
- Adds a `wtlist` helper that holds the temporary entries back and prints them after everything else. Agent worktrees stay visible and reachable by number without displacing the permanent ones ahead of them
- `wt` resolves paths from `git worktree list --porcelain -z`, read into an array. NUL-delimited records are the only format that keeps a path containing a space or a newline intact — plain `--porcelain` leaves a newline-bearing path split across two lines, which would invent an entry and pull the numbering out of step. `wtl` keeps reordering git's human-readable listing so it retains the commit and branch columns, matching against the whole line, which is equivalent to matching the path because git forbids a refname component beginning with a dot
- Indexing an array also retires `sed -n "${1}p"`, which was a sed program rather than a subscript: `wt '1w /some/file'` truncated an arbitrary file, `wt '1r /some/file'` read one back, and a bare `wt` printed every line into `cd`. A numeric guard now turns away anything that is not a plain number
- Both refusals report on stderr and return non-zero. A missing worktree used to be announced on stdout while `wt` still exited successfully, so `wt 9 && bin/dev` went on to run the command from wherever the shell already stood
- The loop variable in `_wt_paths` is named `dir` rather than the obvious `path` because zsh ties `path` to `PATH` — a local by that name empties it and `git` stops resolving inside the function. There is a comment on the declaration so a future tidy-up does not reintroduce it
- Split out of #91, which needs this fix but is otherwise about isolating review subagents. #91 will be rebased to drop its copy of this change

Requires `source ~/.zshrc` to pick up the new functions; shells already running keep the old `wt`.

## Test plan

- [x] `zsh -n home/.zshrc` parses
- [x] Ordering verified in a scratch repo holding a permanent worktree, one under a path containing a space, one under a path containing a newline, and an agent worktree nested beneath `My Code/.claude/worktrees/` — `wtl` lists the agent entry last, and the earlier `index($1, ...)` form left it interleaved because `$1` stops at the first space
- [x] `wt N` lands in the directory `wtl` numbers N for every entry, including the space-containing and newline-containing paths that the previous `awk '{print $1}'` truncated
- [x] Confirmed against git 2.55.0 that `git worktree list --porcelain` without `-z` splits a newline-bearing path across two lines while `-z` keeps the record whole, and that the human-readable listing C-quotes it onto one line — the reason the two consumers read different formats
- [x] `wt abc`, `wt -1`, `wt ''`, `wt '1p;2'`, and `wt '1w /tmp/CLOBBER_ME'` are all refused with `Usage: wt <number>` and exit 1, and the `w` attempt created no file
- [x] `wt 0` and `wt 99` report not found on stderr and exit 1
- [x] `wt 2 && …` runs the following command and `wt 99 && …` does not, with `wt 99 || …` firing as expected
- [x] `wtl` surfaces `fatal: not a git repository` again outside a repository, where the first revision of this branch printed nothing at all
- [x] Numbering and path resolution checked against the real dotfiles worktrees
- [x] No line exceeds 100 characters
